### PR TITLE
Fixes Component Error Handling

### DIFF
--- a/docs/src/CustomComponent.jsx
+++ b/docs/src/CustomComponent.jsx
@@ -195,8 +195,12 @@ var CustomComponent = React.createClass({
       }
     } catch (err) {
       this.setTimeout(function() {
+        if(typeof console !== 'undefined')
+        {
+          console.error(err);
+        }
         React.render(
-          <UIToolkit.BootstrapAlert bsStyle="danger">{err.toString()}</UIToolkit.BootstrapAlert>,
+          <div className="alert alert-danger">{err.toString()}</div>,
           mountNode
         );
       }, 500);

--- a/src/components/flag/code/views/flagView.jsx
+++ b/src/components/flag/code/views/flagView.jsx
@@ -17,7 +17,9 @@ module.exports = React.createClass({
       'left top',
       'left bottom',
       'right top',
-      'right bottom'
+      'right bottom',
+      'left right',
+      'right left'
     ])
   },
 

--- a/src/components/flag/code/views/flagView.jsx
+++ b/src/components/flag/code/views/flagView.jsx
@@ -5,7 +5,20 @@ module.exports = React.createClass({
   propTypes: {
     purpose: React.PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
     size: React.PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large']),
-    position: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left'])
+    position: React.PropTypes.oneOf([
+      'top',
+      'right',
+      'bottom',
+      'left',
+      'top left',
+      'bottom left',
+      'top right',
+      'bottom right',
+      'left top',
+      'left bottom',
+      'right top',
+      'right bottom'
+    ])
   },
 
   render: function() {


### PR DESCRIPTION
There was a try / catch block that passed all JS errors to a component that did not exist.  I updated this and also called a console.error to get a stack trace on the actual file and line that was is causing the problem.  Without the console.error no developer output is generated in the Docs if there was a problem with a specific component.

Also fixed the flag component to add the additional position properties that were missing, which causes warnings on every page view.