### PR TITLE
Add 'license' field to package specification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ui-toolkit",
   "version": "0.8.2",
   "description": "UI Toolkit",
+  "license": "MIT",
   "main": "src/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
According to the repository's `LICENSE.md` file. Makes package spec more compliant and gets rid of the annoying warning when running `npm install`.