### PR TITLE
Add browserify compilation options into package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "mocha-lcov-reporter": "0.0.2",
     "react-tools": "^0.13.2",
     "sinon": "^1.14.1"
+  },
+  "browserify": {
+    "transform": [ "reactify" ]
   }
 }


### PR DESCRIPTION
When building with browserify it won't correctly reactify the `.jsx` `require`s unless it is included in the `package.json` for that NPM module.  This fixes that.