### PR TITLE
fixing the responsive images in docs

### DIFF
--- a/docs/examples/ImageResponsive.jsx
+++ b/docs/examples/ImageResponsive.jsx
@@ -1,7 +1,7 @@
 var image = {
-  srcSet: '/assets/component-image/panda2000.jpg 2000w, /assets/component-image/panda1500.jpg 1500w, /assets/component-image/panda1000.jpg 1000w, /assets/component-image/panda500.jpg 500w',
+  srcSet: 'https://open-source.holidayextras.com/ui-toolkit/images/panda2000.jpg 2000w, https://open-source.holidayextras.com/ui-toolkit/images/panda1500.jpg 1500w, https://open-source.holidayextras.com/ui-toolkit/images/panda1000.jpg 1000w, https://open-source.holidayextras.com/ui-toolkit/images/panda500.jpg 500w',
   src: '/assets/component-image/panda.jpg',
-  alt: 'Delicious strawberry cheesecake'
+  alt: 'A cute panda'
 };
 
 var example = (

--- a/docs/examples/ImageResponsive.jsx
+++ b/docs/examples/ImageResponsive.jsx
@@ -1,6 +1,6 @@
 var image = {
   srcSet: 'https://open-source.holidayextras.com/ui-toolkit/images/panda2000.jpg 2000w, https://open-source.holidayextras.com/ui-toolkit/images/panda1500.jpg 1500w, https://open-source.holidayextras.com/ui-toolkit/images/panda1000.jpg 1000w, https://open-source.holidayextras.com/ui-toolkit/images/panda500.jpg 500w',
-  src: '/assets/component-image/panda.jpg',
+  src: 'https://open-source.holidayextras.com/ui-toolkit/images/panda500.jpg',
   alt: 'A cute panda'
 };
 


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
- The responsive images component went live last week, however the images on the docs were broken.
- This replaces the broken links with a CDN fronted set of images

#### What tests does this PR have?
None

#### How can this be tested?
run `grunt docs` and scroll down to images, you should see a very cute :panda_face:

#### Screenshots / Screencast
<img width="870" alt="screen shot 2015-10-08 at 14 41 28" src="https://cloud.githubusercontent.com/assets/778942/10367881/b94ac76a-6dca-11e5-8ce3-6d334eba9920.png">

#### What gif best describes how you feel about this work?

![Pan-dog](https://media.giphy.com/media/Ek333DGeQM0x2/giphy.gif)

---
#### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.

#### Software Engineer or Developer review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked all the tests are passing.

#### Software Engineer or project guru review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked all the tests are passing.