### PR TITLE
Move reactify to dependencies

### DIFF
--- a/docs/public/assets/bundle.js
+++ b/docs/public/assets/bundle.js
@@ -30347,7 +30347,7 @@ module.exports = require('./lib/React');
 },{"./lib/React":117}],250:[function(require,module,exports){
 module.exports={
   "name": "ui-toolkit",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "UI Toolkit",
   "license": "MIT",
   "main": "index.js",
@@ -30408,6 +30408,7 @@ module.exports={
     "react-data-attributes-mixin": "git://github.com/holidayextras/react-data-attributes-mixin",
     "react-dom": "^0.14.2",
     "react-intl": "^2.0.0-pr-3",
+    "reactify": "^1.1.1",
     "require-directory": "^2.0.0",
     "requirejs": "~2.1.9"
   },
@@ -30431,7 +30432,6 @@ module.exports={
     "mocha-lcov-reporter": "0.0.2",
     "react-addons-test-utils": "^0.14.2",
     "react-tests-globals-setup": "^1.0.0",
-    "reactify": "^1.1.1",
     "sinon": "^1.14.1"
   },
   "browserify": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-data-attributes-mixin": "git://github.com/holidayextras/react-data-attributes-mixin",
     "react-dom": "^0.14.2",
     "react-intl": "^2.0.0-pr-3",
+    "reactify": "^1.1.1",
     "require-directory": "^2.0.0",
     "requirejs": "~2.1.9"
   },
@@ -84,7 +85,6 @@
     "mocha-lcov-reporter": "0.0.2",
     "react-addons-test-utils": "^0.14.2",
     "react-tests-globals-setup": "^1.0.0",
-    "reactify": "^1.1.1",
     "sinon": "^1.14.1"
   },
   "browserify": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
When including the ui-toolkit in a react component I got an error because reactify wasn't present.This is due to the fact it was under devDependencies rather than dependencies.

#### What tests does this PR have?
n/a

#### How can this be tested?
Just make sure it's not broken

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?
![](http://i.giphy.com/KClrIEFayJMiI.gif)

---

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru