### PR TITLE
Updating tile to be more fluid

### DIFF
--- a/src/components/tile/_tile.less
+++ b/src/components/tile/_tile.less
@@ -5,7 +5,7 @@
 .component-tile {
   border-radius: @tiles-border-radius;
   border: @tiles-border-size @tiles-border-style @tiles-border-color;
-  .caption {
+  .component-tile-block {
     padding: @padding-default;
   }
   img {

--- a/src/components/tile/tile.jsx
+++ b/src/components/tile/tile.jsx
@@ -6,15 +6,15 @@ module.exports = React.createClass({
   propTypes: {
     children: React.PropTypes.any,
     image: React.PropTypes.object.isRequired,
-    title: React.PropTypes.string.isRequired
+    title: React.PropTypes.string
   },
 
   render: function() {
     return (
       <div className="component-tile">
         <Image {...this.props.image} />
-        <div className="caption">
-          <h4>{this.props.title}</h4>
+        <div className="component-tile-block">
+          {(this.props.title) ? <h4>{this.props.title}</h4> : null}
           {this.props.children}
         </div>
       </div>

--- a/test/components/tile-test.jsx
+++ b/test/components/tile-test.jsx
@@ -23,9 +23,25 @@ describe('TileComponent', function() {
     assert.isDefined(component);
   });
 
+  it('should render an img', function() {
+    var tile = TestUtils.renderIntoDocument(
+      <TileComponent image={img}>bar</TileComponent>
+    );
+    var renderedImg = TestUtils.scryRenderedDOMComponentsWithTag(tile, 'img');
+    assert.equal(renderedImg.length, 1);
+  });
+
+  it('should render a tile-block', function() {
+    var tile = TestUtils.renderIntoDocument(
+      <TileComponent image={img}>bar</TileComponent>
+    );
+    var renderedTile = TestUtils.findRenderedDOMComponentWithClass(tile, 'component-tile-block');
+    assert.isDefined(renderedTile);
+  });
+
   it('should render a tile/card with a title', function() {
     var tile = TestUtils.renderIntoDocument(
-      <TileComponent image={img} title="foo" >You have been successful</TileComponent>
+      <TileComponent image={img} title="foo" >bar</TileComponent>
     );
     var h4s = TestUtils.scryRenderedDOMComponentsWithTag(tile, 'h4');
     assert.equal(h4s.length, 1);

--- a/test/components/tile-test.jsx
+++ b/test/components/tile-test.jsx
@@ -6,17 +6,30 @@ var TileComponent = require('../../src/components/tile/tile.jsx');
 
 describe('TileComponent', function() {
 
-  it('is an element', function() {
-    var img = {
+  var img
+
+  beforeEach(function() {
+    img = {
       src: 'foo',
       alt: 'bar'
     };
+  });
 
+  it('is an element', function() {
     var component = TestUtils.renderIntoDocument(
-    	<TileComponent image={img} title="title" />
+      <TileComponent image={img} />
     );
-    
+
     assert.isDefined(component);
+  });
+
+  it('should render a tile/card with a title', function() {
+    var tile = TestUtils.renderIntoDocument(
+      <TileComponent image={img} title="foo" >You have been successful</TileComponent>
+    );
+    var h4s = TestUtils.scryRenderedDOMComponentsWithTag(tile, 'h4');
+    assert.equal(h4s.length, 1);
+    assert.equal(h4s[0].textContent, 'foo');
   });
 
 });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
- The tile on the Toolkit is a bit prescriptive, it demands a title and then doesn't allow you to move that title anywhere. Instead I've made title optional.
- I've also updated some of the styling and classes for the component to make it a bit more robust.

#### What tests does this PR have?
There was no test to ensure the title was there. I've now added a few tests to ensure..
- Title is present when passed in props
- Image is present
- Tile block is present

#### How can this be tested?
`npm run docs`
Go to the ui-toolkit docs and remove the title in the code editor. You shouldn't receive any react warnings.

#### Screenshots / Screencast
<img width="701" alt="screen shot 2016-01-27 at 12 11 26" src="https://cloud.githubusercontent.com/assets/778942/12613079/1d38b176-c4ef-11e5-92f5-b33192084300.png">


#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/5fXJmIyVrIkNy/giphy.gif)
---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru