### PR TITLE
CEX-570 add onBlur event to input component

### DIFF
--- a/docs/src/Components.jsx
+++ b/docs/src/Components.jsx
@@ -117,6 +117,7 @@ var Components = React.createClass({
               <li><code>readOnly</code> Boolean - Whether to set the Input Field to Read Only</li>
               <li><code>required</code> Boolean - Whether to set the Input Field to be Required</li>
               <li><code>handleChange</code> Function - Optional Function which is called onChange</li>
+              <li><code>handleBlur</code> Function - Optional Function which is called onBlur</li>
             </ul>
           </article>
 

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -24,6 +24,7 @@ module.exports = React.createClass({
     validator: React.PropTypes.instanceOf(RegExp),
     errorMessage: React.PropTypes.string,
     children: React.PropTypes.string,
+    handleBlur: React.PropTypes.func,
     handleChange: React.PropTypes.func,
     data: React.PropTypes.object
   },
@@ -123,6 +124,7 @@ module.exports = React.createClass({
           aria-labelledby={this.props.label}
           id={this.props.id}
           placeholder={this.props.placeholder}
+          onBlur={this.props.handleBlur}
           onChange={this.handleChange}
           disabled={this.props.disabled}
           readOnly={this.props.readOnly}

--- a/test/components/input-test.jsx
+++ b/test/components/input-test.jsx
@@ -46,6 +46,18 @@ describe('InputComponent', function() {
 
   });
 
+  it('should call handleBlur prop when value changes', function() {
+    var handleBlur = sinon.spy();
+    var input = TestUtils.renderIntoDocument(
+      <InputView type="test" label="Full Name" handleBlur={handleBlur} />
+    );
+
+    var renderedInput = TestUtils.findRenderedDOMComponentWithClass(input, 'component-input-field');
+
+    TestUtils.Simulate.blur(renderedInput, { target: {value: 'changed value' } });
+    assert.ok(handleBlur.calledOnce);
+  });
+
   it('should call handleChange prop when value changes', function() {
     var handleChange = sinon.spy();
     var input = TestUtils.renderIntoDocument(


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Adds an `handleBlur` prop to the `Input` component. This will allow us to run functions when a user has finished interacting with an input field. Currently there is only a `handleChange` prop which will run whenever a user types.
#### What tests does this PR have?
`test/components/input-test.jsx`
#### How can this be tested?
I've created the `toolkit-blur-test` branch in the `react-car-reg-lookup` for testing this. `npm-link` the toolkit, run an `npm run build` and you will be able to test these changes in that repo.

When you blur on the input field you will see a `console.log` with the value of the input field
#### Screenshots / Screencast
![](http://g.recordit.co/z0Jl4nELvB.gif)
#### What gif best describes how you feel about this work?
![](http://lostangelesblog.com/wp-content/uploads/2015/08/tumblr_n1n0vgoaU31tt7s0fo1_500.gif)

---

- [ ] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** \*
- [ ] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru