### PR TITLE
HEHA-315 Weather: accept 0 as a temperature

### DIFF
--- a/docs/examples/Weather.jsx
+++ b/docs/examples/Weather.jsx
@@ -2,6 +2,7 @@ var example = (
   <div className="example-weather">
     <UIToolkit.Weather type="sunny" temperature={22} unit="C" date="2016-07-25" />
     <UIToolkit.Weather type="partly-cloudy" temperature={17} unit="C" date="2016-07-26" />
+    <UIToolkit.Weather type="heavy-snow" temperature={0} unit="C" date="2016-07-29" />
     <UIToolkit.Weather type="cloudy" temperature={14} unit="F" date="2016-07-27" />
     <UIToolkit.Weather type="light-rain" temperature={10} unit="C" date="2016-07-28" format="dddd"/>
     <UIToolkit.Weather type="heavy-rain" temperature={5} unit="C" date="2016-07-29T09:00" format="HH:mm" />

--- a/src/components/weather/weather.jsx
+++ b/src/components/weather/weather.jsx
@@ -31,7 +31,7 @@ module.exports = React.createClass({
     return (
       <div className="component-weather">
         <div className={this.props.type}><span>{this.props.type}</span></div>
-        {(this.props.temperature) ? <div>{this.props.temperature}<abbr title={unitName}>{unit}</abbr></div> : null}
+        {(this.props.temperature || this.props.temperature === 0) ? <div>{this.props.temperature}<abbr title={unitName}>{unit}</abbr></div> : null}
         {(this.props.date) ? <div>{moment(date, expectedFormat, true).format(displayFormat)}</div> : null}
       </div>
     );

--- a/test/components/weather-test.jsx
+++ b/test/components/weather-test.jsx
@@ -233,6 +233,16 @@ describe('WeatherComponent', function() {
       var renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherTemp, 'div')[2];
       assert.equal(renderedWeather.textContent, '20K');
     });
+
+    it('displays a temperature at 0', function() {
+      var weatherTemp = TestUtils.renderIntoDocument(
+        <WeatherComponent type={type} temperature={0} unit="C"/>
+      );
+
+      var renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherTemp, 'div')[2];
+      assert.equal(renderedWeather.textContent, '0°C');
+    });
+
   });
 
 });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
We don't render a temperature when it's `0` because JS evaluates `0` as falsy

#### What tests does this PR have?
Added a regression test for this in `weather-test.jsx`

#### How can this be tested?
`npm run docs` & check [http://localhost:4000/#weather](http://localhost:4000/#weather), I've conveniently added an example with `0` to see it working

#### Screenshots / Screencast
![screen shot 2016-02-16 at 15 47 19](https://cloud.githubusercontent.com/assets/1485654/13081407/98d1278e-d4c4-11e5-8c1c-e078fe4edd82.png)

#### What gif best describes how you feel about this work?
![freezing](http://ak-hdl.buzzfed.com/static/2015-01/21/13/enhanced/webdr05/anigif_enhanced-buzz-6073-1421866019-9.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru