### PR TITLE
fixed annoying version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/holidayextras/ui-toolkit",
   "engines": {
-    "node": ">0.10 <0.12",
+    "node": ">0.10 <=0.12",
     "npm": "~2.14.8"
   },
   "dependencies": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

When you install the ui-toolkit as a dependancy you receive the following warning:

    npm WARN engine ui-toolkit@0.28.1: wanted: {"node":">0.10 <0.12","npm":"~2.14.8"} (current: {"node":"0.12.9","npm":"2.14.9"})

This change allows node 0.12 to be used without warning.

#### What tests does this PR have?

No tests as its just a tooling change.

#### How can this be tested?

Change your `package.json` to use this branch rather than a set version and you should not see the above version when you `npm install`.

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/13214867/e4bdd302-d949-11e5-84f2-ee9fb3815c56.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru