### PR TITLE
Remove same day countdown zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/ui-toolkit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "UI Toolkit",
   "license": "MIT",
   "main": "index.js",

--- a/src/components/countdown/countdown.jsx
+++ b/src/components/countdown/countdown.jsx
@@ -16,7 +16,7 @@ module.exports = React.createClass({
     this.countdownManager = new CountdownManager(date);
     return {
       time: this.countdownManager.time()
-    }
+    };
   },
 
   componentDidMount: function() {

--- a/src/components/countdown/countdown.jsx
+++ b/src/components/countdown/countdown.jsx
@@ -12,16 +12,11 @@ module.exports = React.createClass({
   },
 
   getInitialState: function() {
-    return this.countdownManagerState();
-  },
-
-  countdownManagerState: function(dateUpdate) {
-    var date = { startDate: (dateUpdate || this.props.until) };
-    var countdownManager = new CountdownManager(date);
+    var date = { startDate: this.props.until };
+    this.countdownManager = new CountdownManager(date);
     return {
-      countdownManager: countdownManager,
-      time: countdownManager.time()
-    };
+      time: this.countdownManager.time()
+    }
   },
 
   componentDidMount: function() {
@@ -34,22 +29,23 @@ module.exports = React.createClass({
 
   componentWillReceiveProps: function(nextProps) {
     this.stopCountdownManager();
-    this.setState(this.countdownManagerState(nextProps.date), this.startCountdownManager);
+    this.countdownManager.restart(nextProps.date);
+    this.setState({ time: this.countdownManager.time() });
   },
 
   startCountdownManager: function() {
-    this.state.countdownManager.start(this.onCountdown);
+    this.countdownManager.start(this.onCountdown);
   },
 
   onCountdown: function(time) {
-    if (this.state.countdownManager.hasDatePassed()) {
-      this.state.countdownManager.stop();
+    if (this.countdownManager.hasDatePassed()) {
+      this.countdownManager.stop();
     }
     this.setState({ time: time });
   },
 
   stopCountdownManager: function() {
-    return this.state.countdownManager.stop();
+    return this.countdownManager.stop();
   },
 
   render: function() {

--- a/src/components/countdown/countdown.jsx
+++ b/src/components/countdown/countdown.jsx
@@ -42,6 +42,9 @@ module.exports = React.createClass({
   },
 
   onCountdown: function(time) {
+    if(this.state.countdownManager.hasDatePassed()) {
+      this.state.countdownManager.stop();
+    }
     this.setState({ time: time });
   },
 

--- a/src/components/countdown/countdown.jsx
+++ b/src/components/countdown/countdown.jsx
@@ -42,7 +42,7 @@ module.exports = React.createClass({
   },
 
   onCountdown: function(time) {
-    if(this.state.countdownManager.hasDatePassed()) {
+    if (this.state.countdownManager.hasDatePassed()) {
       this.state.countdownManager.stop();
     }
     this.setState({ time: time });

--- a/src/components/countdown/lib/countdown.js
+++ b/src/components/countdown/lib/countdown.js
@@ -25,11 +25,9 @@ countdown.untilString = function(untilDate) {
 
 // Private functions from here
 countdown._pad = function(number) {
+  var prefix = number < 0 ? '-' : '';
   number = Math.abs(Math.floor(number));
-  if (number > 9) {
-    return '' + number;
-  }
-  return '0' + number;
+  return prefix + (number > 9 ? '' : '0') + number;
 };
 
 countdown._roundTowardsZero = function(number) {
@@ -39,16 +37,9 @@ countdown._roundTowardsZero = function(number) {
   return '' + Math.ceil(number);
 };
 
-countdown._isSameDay = function(moment1, moment2) {
-  return moment(moment1).isSame(moment2, 'day');
-};
-
 countdown._durationFromNow = function(untilDate) {
   var until = moment(untilDate);
   var now = moment();
-  if (this._isSameDay(until, now)) {
-    return moment.duration();
-  }
   var seconds = until.diff(now, 'seconds');
   return moment.duration(seconds, 'seconds');
 };

--- a/src/components/countdown/lib/countdownManager.js
+++ b/src/components/countdown/lib/countdownManager.js
@@ -25,6 +25,10 @@ CountdownManager.prototype.intervalCounter = function(callback) {
   }.bind(this);
 };
 
+CountdownManager.prototype.hasDatePassed = function() {
+  return moment(this.countdownDate()).isBefore(moment());
+};
+
 CountdownManager.prototype.countdownDate = function(callback) {
   return (typeof callback === 'function') ? callback(this.date.startDate) : this.date.startDate;
 };

--- a/src/components/countdown/lib/countdownManager.js
+++ b/src/components/countdown/lib/countdownManager.js
@@ -21,7 +21,7 @@ CountdownManager.prototype.stop = function() {
 
 CountdownManager.prototype.restart = function(date) {
   this.stop();
-  if(date) {
+  if (date) {
     this.date = date;
   }
   this.start();

--- a/src/components/countdown/lib/countdownManager.js
+++ b/src/components/countdown/lib/countdownManager.js
@@ -19,6 +19,14 @@ CountdownManager.prototype.stop = function() {
   return moment();
 };
 
+CountdownManager.prototype.restart = function(date) {
+  this.stop();
+  if(date) {
+    this.date = date;
+  }
+  this.start();
+};
+
 CountdownManager.prototype.intervalCounter = function(callback) {
   return function() {
     callback(this.time());

--- a/src/components/countdown/test/countdownView-test.jsx
+++ b/src/components/countdown/test/countdownView-test.jsx
@@ -26,7 +26,7 @@ describe('CountdownComponent', function() {
     assert.equal(countdown.props.until, '2016-07-27');
   });
 
-  it('check the countdown mnagaer states time is set correctly', function() {
+  it('check the countdown manager states time is set correctly', function() {
     var date = '2016-07-27';
     var countdown = TestUtils.renderIntoDocument(
       <CountdownComponent until={date} />

--- a/test/components/countdown-test.js
+++ b/test/components/countdown-test.js
@@ -40,16 +40,6 @@ describe('Countdown tests', function() {
       });
     });
 
-    it('returns 0s for the same day', function() {
-      var sameDay = moment().add(20, 'seconds').format(dateFormat);
-      assert.deepEqual(countdown.until(sameDay), {
-        days: '0',
-        hours: '00',
-        minutes: '00',
-        seconds: '00'
-      });
-    });
-
     it('returns negative day for the past', function() {
       var pastDay = moment().subtract(2, 'days').format(dateFormat);
       assert.ok(countdown.until(pastDay).days < 0);
@@ -97,6 +87,15 @@ describe('Countdown tests', function() {
 
     });
 
+    describe('when the number is a negative integer', function() {
+
+      it('returns the number with a negation prefix', function() {
+        assert.equal(countdown._pad(-5), '-05');
+        assert.equal(countdown._pad(-20), '-20');
+      });
+
+    });
+
   });
 
   describe('_roundTowardsZero', function() {
@@ -113,39 +112,6 @@ describe('Countdown tests', function() {
 
       it('ceils the number', function() {
         assert.equal(countdown._roundTowardsZero(-1.9), -1);
-      });
-
-    });
-
-  });
-
-  describe('_isSameDay', function() {
-
-    var moment1 = null;
-    var moment2 = null;
-
-    describe('when the two dates are not the same day', function() {
-
-      beforeEach(function() {
-        moment1 = moment('2015-01-01');
-        moment2 = moment('2015-01-02');
-      });
-
-      it('is false', function() {
-        assert.equal(countdown._isSameDay(moment1, moment2), false);
-      });
-
-    });
-
-    describe('when the two dates are the same day', function() {
-
-      beforeEach(function() {
-        moment1 = moment('2015-01-02');
-        moment2 = moment('2015-01-02');
-      });
-
-      it('is true', function() {
-        assert.equal(countdown._isSameDay(moment1, moment2), true);
       });
 
     });

--- a/test/components/countdownManager-test.js
+++ b/test/components/countdownManager-test.js
@@ -144,7 +144,7 @@ describe('Countdown Manager', function() {
         assert.isTrue(countdownManager.hasDatePassed());
       });
     });
-    
+
     describe('when the start date is in the future', function() {
       beforeEach(function() {
         sinon.stub(countdownManager, 'countdownDate').returns('1970-01-01T00:01');
@@ -158,7 +158,7 @@ describe('Countdown Manager', function() {
         assert.isFalse(countdownManager.hasDatePassed());
       });
     });
-    
+
   });
 
 });

--- a/test/components/countdownManager-test.js
+++ b/test/components/countdownManager-test.js
@@ -8,22 +8,24 @@ var sinon = require('sinon');
 
 describe('Countdown Manager', function() {
 
-  var clock = null;
-  var date = null;
-  var countdownManager = null;
-  var callbackSpy = null;
+  var sandbox;
+  var clock;
+  var date;
+  var countdownManager;
+  var callbackSpy;
 
   beforeEach(function() {
-    clock = sinon.useFakeTimers();
+    sandbox = sinon.sandbox.create();
+    clock = sandbox.useFakeTimers();
     date = {
       startDate: '2016-07-27'
     };
     countdownManager = new CountdownManager(date);
-    callbackSpy = sinon.spy();
+    callbackSpy = sandbox.spy();
   });
 
   afterEach(function() {
-    clock.restore();
+    sandbox.restore();
   });
 
   describe('start', function() {
@@ -62,13 +64,8 @@ describe('Countdown Manager', function() {
     var dateToPass = '1970-01-01T13:00';
 
     beforeEach(function() {
-      countdownStartStub = sinon.stub(countdownManager, 'start');
-      countdownStopStub = sinon.stub(countdownManager, 'stop');
-    });
-
-    afterEach(function() {
-      countdownManager.start.restore();
-      countdownManager.stop.restore();
+      countdownStartStub = sandbox.stub(countdownManager, 'start');
+      countdownStopStub = sandbox.stub(countdownManager, 'stop');
     });
 
     describe('with no date passed', function() {
@@ -105,7 +102,7 @@ describe('Countdown Manager', function() {
     var intervalFunction = null;
 
     beforeEach(function() {
-      sinon.stub(countdownManager, 'time').returns('test');
+      sandbox.stub(countdownManager, 'time').returns('test');
       intervalFunction = countdownManager.intervalCounter(callbackSpy);
       intervalFunction();
     });
@@ -158,14 +155,10 @@ describe('Countdown Manager', function() {
 
     beforeEach(function() {
       countdownUntilStub = sinon.stub(countdown, 'until');
-      sinon.stub(countdownManager, 'countdownDate').returns(countdownDateValue);
+      sandbox.stub(countdownManager, 'countdownDate').returns(countdownDateValue);
 
       currentMoment = 'test';
       countdownManager.time(currentMoment);
-    });
-
-    afterEach(function() {
-      countdownManager.countdownDate.restore();
     });
 
     it('calls countdown until with countdownDate & currentMoment', function() {
@@ -177,11 +170,7 @@ describe('Countdown Manager', function() {
 
     describe('when the start date has passed', function() {
       beforeEach(function() {
-        sinon.stub(countdownManager, 'countdownDate').returns('1969-12-31T23:59');
-      });
-
-      afterEach(function() {
-        countdownManager.countdownDate.restore();
+        sandbox.stub(countdownManager, 'countdownDate').returns('1969-12-31T23:59');
       });
 
       it('should return true', function() {
@@ -191,11 +180,7 @@ describe('Countdown Manager', function() {
 
     describe('when the start date is in the future', function() {
       beforeEach(function() {
-        sinon.stub(countdownManager, 'countdownDate').returns('1970-01-01T00:01');
-      });
-
-      afterEach(function() {
-        countdownManager.countdownDate.restore();
+        sandbox.stub(countdownManager, 'countdownDate').returns('1970-01-01T00:01');
       });
 
       it('should return false', function() {

--- a/test/components/countdownManager-test.js
+++ b/test/components/countdownManager-test.js
@@ -60,7 +60,7 @@ describe('Countdown Manager', function() {
     var countdownStartStub;
     var countdownStopStub;
     var dateToPass = '1970-01-01T13:00';
-    
+
     beforeEach(function() {
       countdownStartStub = sinon.stub(countdownManager, 'start');
       countdownStopStub = sinon.stub(countdownManager, 'stop');
@@ -93,10 +93,10 @@ describe('Countdown Manager', function() {
         countdownManager.restart();
       });
 
-      it('should update the date property', function () {
+      it('should update the date property', function() {
         assert(countdownManager.date, dateToPass);
       });
-      
+
     });
   });
 

--- a/test/components/countdownManager-test.js
+++ b/test/components/countdownManager-test.js
@@ -56,6 +56,50 @@ describe('Countdown Manager', function() {
 
   });
 
+  describe('restart', function() {
+    var countdownStartStub;
+    var countdownStopStub;
+    var dateToPass = '1970-01-01T13:00';
+    
+    beforeEach(function() {
+      countdownStartStub = sinon.stub(countdownManager, 'start');
+      countdownStopStub = sinon.stub(countdownManager, 'stop');
+    });
+
+    afterEach(function() {
+      countdownManager.start.restore();
+      countdownManager.stop.restore();
+    });
+
+    describe('with no date passed', function() {
+
+      beforeEach(function() {
+        countdownManager.restart();
+      });
+
+      it('should call stop', function() {
+        assert.ok(countdownStopStub.calledOnce);
+      });
+
+      it('should call start', function() {
+        assert.ok(countdownStartStub.calledOnce);
+      });
+
+    });
+
+    describe('with a date passed', function() {
+
+      beforeEach(function() {
+        countdownManager.restart();
+      });
+
+      it('should update the date property', function () {
+        assert(countdownManager.date, dateToPass);
+      });
+      
+    });
+  });
+
   describe('intervalCounter', function() {
 
     var intervalFunction = null;

--- a/test/components/countdownManager-test.js
+++ b/test/components/countdownManager-test.js
@@ -8,16 +8,13 @@ var sinon = require('sinon');
 
 describe('Countdown Manager', function() {
 
-  var timer = null;
+  var clock = null;
   var date = null;
   var countdownManager = null;
   var callbackSpy = null;
 
-  before(function() {
-    timer = sinon.useFakeTimers();
-  });
-
   beforeEach(function() {
+    clock = sinon.useFakeTimers();
     date = {
       startDate: '2016-07-27'
     };
@@ -25,15 +22,15 @@ describe('Countdown Manager', function() {
     callbackSpy = sinon.spy();
   });
 
-  after(function() {
-    timer.restore();
+  afterEach(function() {
+    clock.restore();
   });
 
   describe('start', function() {
 
     beforeEach(function() {
       countdownManager.start(callbackSpy);
-      timer.tick(CountdownManager.countdownInterval);
+      clock.tick(CountdownManager.countdownInterval);
     });
 
     it('sets interval countdown', function() {
@@ -46,7 +43,7 @@ describe('Countdown Manager', function() {
 
     beforeEach(function() {
       countdownManager.stop(callbackSpy);
-      timer.tick(CountdownManager.countdownInterval);
+      clock.tick(CountdownManager.countdownInterval);
     });
 
     it('clears interval countdown', function() {
@@ -123,9 +120,45 @@ describe('Countdown Manager', function() {
       countdownManager.time(currentMoment);
     });
 
+    afterEach(function() {
+      countdownManager.countdownDate.restore();
+    });
+
     it('calls countdown until with countdownDate & currentMoment', function() {
       assert.ok(countdownUntilStub.calledWith(countdownDateValue, currentMoment));
     });
+  });
+
+  describe('hasDatePassed', function() {
+
+    describe('when the start date has passed', function() {
+      beforeEach(function() {
+        sinon.stub(countdownManager, 'countdownDate').returns('1969-12-31T23:59');
+      });
+
+      afterEach(function() {
+        countdownManager.countdownDate.restore();
+      });
+
+      it('should return true', function() {
+        assert.isTrue(countdownManager.hasDatePassed());
+      });
+    });
+    
+    describe('when the start date is in the future', function() {
+      beforeEach(function() {
+        sinon.stub(countdownManager, 'countdownDate').returns('1970-01-01T00:01');
+      });
+
+      afterEach(function() {
+        countdownManager.countdownDate.restore();
+      });
+
+      it('should return false', function() {
+        assert.isFalse(countdownManager.hasDatePassed());
+      });
+    });
+    
   });
 
 });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Makes countdown clock end at zero & takes a time into account. (removes the feature of displaying zero on the same day regardless of time passed in).

#### What tests does this PR have?
I have added a couple of additional tests for the functionality I have included

#### How can this be tested?
I would run the docs as per the readme & then see the countdown clock behaving as expected (pass in a todays date & time + 3o seconds & watch it stop on zero).

#### Screenshots / Screencast
N/A

#### What gif best describes how you feel about this work?
![Countdown](https://img.buzzfeed.com/buzzfeed-static/static/2015-01/16/7/enhanced/webdr06/anigif_enhanced-661-1421411482-2.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru