### PR TITLE
CON-1743: Add onLoad event handler for Image component

### DIFF
--- a/docs/src/Components.jsx
+++ b/docs/src/Components.jsx
@@ -91,6 +91,7 @@ var Components = React.createClass({
             <ul>
               <li><code>alt</code> String - Image alt attribute</li>
               <li><code>handleClick</code> Function - handle click events on the image</li>
+              <li><code>handleLoad</code> Function - handle the onload event of the image</li>
               <li><code>src</code> String - Image src attribute</li>
               <li><code>href</code> String - an href that wraps the image in an anchor</li>
               <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values (uses <a href="https://github.com/holidayextras/react-data-attributes-mixin" alt="React Data Attributes Mixin">React Data Attributes Mixin</a>)</li>

--- a/src/components/image/image.jsx
+++ b/src/components/image/image.jsx
@@ -10,6 +10,7 @@ module.exports = React.createClass({
     src: React.PropTypes.string.isRequired,
     alt: React.PropTypes.string.isRequired,
     handleClick: React.PropTypes.func,
+    handleLoad: React.PropTypes.func,
     href: React.PropTypes.string,
     srcSet: React.PropTypes.string,
     sizes: React.PropTypes.string
@@ -21,12 +22,12 @@ module.exports = React.createClass({
     if (this.props.href) {
       return (
         <a className="component-image" href={this.props.href} onClick={this.props.handleClick} {...dataAttributes} >
-          <img src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} sizes={sizes} />
+          <img src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} sizes={sizes} onLoad={this.props.handleLoad} />
         </a>
       );
     }
     return (
-      <img className="component-image" src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} sizes={sizes} onClick={this.props.handleClick} {...dataAttributes} />
+      <img className="component-image" src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} sizes={sizes} onClick={this.props.handleClick} onLoad={this.props.handleLoad} {...dataAttributes} />
     );
   }
 });

--- a/test/components/image-test.jsx
+++ b/test/components/image-test.jsx
@@ -10,8 +10,10 @@ describe('ImageComponent', function() {
   var src = null;
   var alt = null;
   var handleClick = null;
+  var handleLoad = null;
   var imageInstance = null;
   var renderedImage = null;
+  var anchorDOMNode = null;
   var imageDOMNode = null;
   var srcSet = null;
   var sizes = null;
@@ -22,6 +24,7 @@ describe('ImageComponent', function() {
     srcSet = '2000w.jpg 2000w, 1500w.jpg 1500w, 1000w.jpg 1000w, 500w.jpg 500w';
     sizes = '100vw';
     handleClick = sinon.spy();
+    handleLoad = sinon.spy();
   });
 
   it('is an element', function() {
@@ -35,40 +38,45 @@ describe('ImageComponent', function() {
     beforeEach(function() {
       href = 'http://this.isa.link';
       imageInstance = TestUtils.renderIntoDocument(
-        <ImageComponent src={src} alt={alt} handleClick={handleClick} href={href} />
+        <ImageComponent src={src} alt={alt} handleClick={handleClick} handleLoad={handleLoad} href={href} />
       );
       renderedImage = TestUtils.findRenderedDOMComponentWithClass(imageInstance, 'component-image');
-      imageDOMNode = renderedImage;
+      anchorDOMNode = renderedImage;
     });
 
     it('should render as an anchor', function() {
-      assert.equal(imageDOMNode.nodeName, 'A');
+      assert.equal(anchorDOMNode.nodeName, 'A');
     });
 
     it('should call handleClick prop when clicked', function() {
-      TestUtils.Simulate.click(imageDOMNode);
+      TestUtils.Simulate.click(anchorDOMNode);
       assert.ok(handleClick.calledOnce);
     });
 
+    it('the image should call handleLoad when img is loaded', function() {
+      imageDOMNode = TestUtils.findRenderedDOMComponentWithTag(imageInstance, 'img');
+      TestUtils.Simulate.load(imageDOMNode);
+      assert.ok(handleLoad.calledOnce);
+    });
+
     it('should render an img tag inside the anchor', function() {
-      assert.equal(imageDOMNode.firstChild.nodeName, 'IMG');
+      assert.equal(anchorDOMNode.firstChild.nodeName, 'IMG');
     });
 
     it('the img should have the correct src attribute from props', function() {
-      assert.equal(imageDOMNode.firstChild.getAttribute('src'), 'foo');
+      assert.equal(anchorDOMNode.firstChild.getAttribute('src'), 'foo');
     });
 
     it('the img should have the correct alt attribute from props', function() {
-      assert.equal(imageDOMNode.firstChild.getAttribute('alt'), 'bar');
+      assert.equal(anchorDOMNode.firstChild.getAttribute('alt'), 'bar');
     });
-
   });
 
   describe('when an href is not passed in', function() {
 
     beforeEach(function() {
       imageInstance = TestUtils.renderIntoDocument(
-        <ImageComponent src={src} alt={alt} handleClick={handleClick} sizes={sizes} srcSet={srcSet} />
+        <ImageComponent src={src} alt={alt} handleClick={handleClick} handleLoad={handleLoad} sizes={sizes} srcSet={srcSet} />
       );
       renderedImage = TestUtils.findRenderedDOMComponentWithClass(imageInstance, 'component-image');
       imageDOMNode = renderedImage;
@@ -91,6 +99,11 @@ describe('ImageComponent', function() {
       assert.ok(handleClick.calledOnce);
     });
 
+    it('should call handleLoad when img is loaded', function() {
+      TestUtils.Simulate.load(imageDOMNode);
+      assert.ok(handleLoad.calledOnce);
+    });
+
     it('should render multiple responsive images', function() {
       assert.equal(imageDOMNode.getAttribute('srcset'), '2000w.jpg 2000w, 1500w.jpg 1500w, 1000w.jpg 1000w, 500w.jpg 500w');
     });
@@ -98,6 +111,5 @@ describe('ImageComponent', function() {
     it('should render a specified start image size', function() {
       assert.equal(imageDOMNode.getAttribute('sizes'), '100vw');
     });
-
   });
 });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Adds a `handleLoad` prop to the Image component.

This is so that we're able to measure the first image load time in tripapp for when we move the parking tile to react.

#### What tests does this PR have?
I've added a couple tests to check that the `handleLoad` prop is called when the load event is triggered.

#### How can this be tested?
N/A

#### Screenshots / Screencast
N/A

#### What gif best describes how you feel about this work?
![](http://i.giphy.com/3oEduXvjS9dADoHxzW.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru