### PR TITLE
CON-1740 add a target attribute to image component

### DIFF
--- a/docs/src/Components.jsx
+++ b/docs/src/Components.jsx
@@ -94,6 +94,7 @@ var Components = React.createClass({
               <li><code>handleLoad</code> Function - handle the onload event of the image</li>
               <li><code>src</code> String - Image src attribute</li>
               <li><code>href</code> String - an href that wraps the image in an anchor</li>
+              <li><code>target</code> String (optional) - passed through to a wrapping anchor if href is provided. See the <a href="#anchor">Anchor</a> component for the set of valid values.</li>
               <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values (uses <a href="https://github.com/holidayextras/react-data-attributes-mixin" alt="React Data Attributes Mixin">React Data Attributes Mixin</a>)</li>
               <li><code>srcset</code> String - a comma separated list of images and their file size, perfect for responsive images</li>
               <li><code>sizes</code> String (optional) - A rough start size for your image. To be used in conjunction with srcset when implementing responsive images. Please note that this is an optimisation only and its default is set to <code>100vw</code></li>

--- a/src/components/image/image.jsx
+++ b/src/components/image/image.jsx
@@ -12,6 +12,7 @@ module.exports = React.createClass({
     handleClick: React.PropTypes.func,
     handleLoad: React.PropTypes.func,
     href: React.PropTypes.string,
+    target: React.PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
     srcSet: React.PropTypes.string,
     sizes: React.PropTypes.string
   },
@@ -21,7 +22,7 @@ module.exports = React.createClass({
     var sizes = this.props.sizes || '100vw';
     if (this.props.href) {
       return (
-        <a className="component-image" href={this.props.href} onClick={this.props.handleClick} {...dataAttributes} >
+        <a className="component-image" href={this.props.href} target={this.props.target} onClick={this.props.handleClick} {...dataAttributes} >
           <img src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} sizes={sizes} onLoad={this.props.handleLoad} />
         </a>
       );

--- a/test/components/image-test.jsx
+++ b/test/components/image-test.jsx
@@ -70,6 +70,33 @@ describe('ImageComponent', function() {
     it('the img should have the correct alt attribute from props', function() {
       assert.equal(anchorDOMNode.firstChild.getAttribute('alt'), 'bar');
     });
+
+    describe('without a target', function() {
+
+      it('should not include a target in the rendered anchor', function() {
+        assert.isNull(imageDOMNode.getAttribute('target'));
+      });
+
+    });
+
+  });
+
+  describe('when a target is passed in', function() {
+
+    beforeEach(function() {
+      var href = 'http://this.isa.link';
+      var target = '_blank';
+      imageInstance = TestUtils.renderIntoDocument(
+        <ImageComponent src={src} alt={alt} handleClick={handleClick} href={href} target={target} />
+      );
+      renderedImage = TestUtils.findRenderedDOMComponentWithClass(imageInstance, 'component-image');
+      imageDOMNode = renderedImage;
+    });
+
+    it('should include the target in the rendered anchor', function() {
+      assert.equal(imageDOMNode.getAttribute('target'), '_blank');
+    });
+
   });
 
   describe('when an href is not passed in', function() {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
Adds a target attribute to the image component. This will allow us to have tile header images that when clicked on show a page in a new tab. This allows us to convert the static product tiles in TripApp to React.

#### What tests does this PR have?
New unit tests.

#### How can this be tested?
* Checkout branch `CON-1740-2` on TripApp
* Run `npm install` to get the version of ui-toolkit from this PR
* Build ui-toolkit since we're not using the pre-built package: `cd node_modules/@holidayextras/ui-toolkit && npm install && npm run build`
* Go back to TripApp root: `cd -`
* Start TripApp with `npm start`
* Make a carpark search and look for a 'Taxi to the Airport' tile on the availability page
* Inspect the tile and see that it is React and that it is good
* Click on the tile image and see that you are taken to a landing page in a new tab

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?
![](http://i.giphy.com/PUDyZmnomyLtK.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2**
- [x] :+1:

**Review 3**
- [x] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.