### PR TITLE
APP-266 Removing the title from the tile component

### DIFF
--- a/docs/examples/Tile.jsx
+++ b/docs/examples/Tile.jsx
@@ -4,7 +4,7 @@ var image = {
 }
 
 var example = (
-  <UIToolkit.Tile image={image} title='Tender sirloin steak with blue cheese dressing' />
+  <UIToolkit.Tile image={image} />
 );
 
 ReactDOM.render(example, mountNode);

--- a/docs/src/Components.jsx
+++ b/docs/src/Components.jsx
@@ -284,7 +284,6 @@ var Components = React.createClass({
             <h4>Attributes</h4>
             <ul>
               <li><code>image</code> Object - Containing <code>src</code> and <code>alt</code> keys</li>
-              <li><code>title</code> String - The title of the tile</li>
             </ul>
           </article>
 

--- a/src/components/tile/tile.jsx
+++ b/src/components/tile/tile.jsx
@@ -5,8 +5,7 @@ var Image = require('../image');
 module.exports = React.createClass({
   propTypes: {
     children: React.PropTypes.any,
-    image: React.PropTypes.object.isRequired,
-    title: React.PropTypes.string
+    image: React.PropTypes.object.isRequired
   },
 
   render: function() {
@@ -14,7 +13,6 @@ module.exports = React.createClass({
       <div className="component-tile">
         <Image {...this.props.image} />
         <div className="component-tile-block">
-          {(this.props.title) ? <h4>{this.props.title}</h4> : null}
           {this.props.children}
         </div>
       </div>

--- a/test/components/tile-test.jsx
+++ b/test/components/tile-test.jsx
@@ -39,13 +39,4 @@ describe('TileComponent', function() {
     assert.isDefined(renderedTile);
   });
 
-  it('should render a tile/card with a title', function() {
-    var tile = TestUtils.renderIntoDocument(
-      <TileComponent image={img} title="foo" >bar</TileComponent>
-    );
-    var h4s = TestUtils.scryRenderedDOMComponentsWithTag(tile, 'h4');
-    assert.equal(h4s.length, 1);
-    assert.equal(h4s[0].textContent, 'foo');
-  });
-
 });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This PR removes the title prop from the tile component as it can just be a child that is passed in, this allows greater flexibility when using the component.

**Its worth noting this is a breaking change**

#### What tests does this PR have?

Updated tests

#### How can this be tested?

Run the tests make sure they still pass, check the code and make sure it makes sense and finally view the resulting change in the docs.

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/ZVDYIE6NZaa40/giphy.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2**
- [ ] :+1:

**Review 3**
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.