### PR TITLE
APP-267 - allowing spread operator on main tile div

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "classnames": "^2.1.0",
     "font-awesome": "^4.3.0",
+    "lodash": "^3.10.0",
     "moment": "~2.10.6",
     "react": "^0.14.2",
     "react-data-attributes-mixin": "git://github.com/holidayextras/react-data-attributes-mixin",

--- a/src/components/tile/tile.jsx
+++ b/src/components/tile/tile.jsx
@@ -1,6 +1,9 @@
 'use strict';
 var React = require('react');
 var Image = require('../image');
+var _ = {
+  omit: require('lodash/object/omit')
+};
 
 module.exports = React.createClass({
   propTypes: {
@@ -9,11 +12,14 @@ module.exports = React.createClass({
   },
 
   render: function() {
+    var { image, children } = this.props;
+    var tileProps = _.omit(this.props, 'image', 'children');
+
     return (
-      <div className="component-tile">
-        <Image {...this.props.image} />
+      <div className="component-tile" {...tileProps}>
+        <Image {...image} />
         <div className="component-tile-block">
-          {this.props.children}
+          {children}
         </div>
       </div>
     );

--- a/test/components/tile-test.jsx
+++ b/test/components/tile-test.jsx
@@ -3,6 +3,7 @@ var React = require('react');
 var TestUtils = require('react-addons-test-utils');
 var assert = require('chai').assert;
 var TileComponent = require('../../src/components/tile/tile.jsx');
+var sinon = require('sinon');
 
 describe('TileComponent', function() {
 
@@ -39,4 +40,14 @@ describe('TileComponent', function() {
     assert.isDefined(renderedTile);
   });
 
+  it('should render any extra props passed to it on the containing div', function() {
+    var onClickHandler = sinon.stub();
+    var tile = TestUtils.renderIntoDocument(
+      <TileComponent image={img} title="foo" onClick={onClickHandler}/>
+    );
+    var renderedTile = TestUtils.findRenderedDOMComponentWithClass(tile, 'component-tile');
+    TestUtils.Simulate.click(renderedTile);
+
+    assert(onClickHandler.called);
+  });
 });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
In using the toolkit components it has come to light that we need to be more flexible in our approach. It's great giving people a framework, but when it's as rigid as this tile it isn't flexible to all the required uses. For instance the grouped product tiles require an onClick handler. To add in a new PR to add an extra prop/attribute to the tile every time we want to slightly change something or add a mouseOver handler seems nonsense. 

Therefore we're adding the spread operator so that, within the confines of it's application we can customise our use of the tile without having to add extra code to the toolkit.

I wanted to use the rest destructuring to do something like `var { image, children, ...props } = this.props` but that wasn't possible with the make-up rules and eslint's support (or intentional lack of) for ES7. I therefore used lodash's omit to achieve the same result (props without the image or children). After some investigation I've found that the lodash method is faster to render in Tripapp than the rest method and the difference between the polyfill and lodash is negligible.

Also: https://facebook.github.io/react/docs/transferring-props.html#transferring-with-underscore
I'm aware the above link is talking about if we don't use JSX, which we do, but ES7 destructuring is subject to change/removal and we need something stable to achieve this. Hence lodash appears to me to be the better option.

I did look at doing this without lodash or the destructuring, but the props are immutable and read only so even if I cloned them I'd still have the same issue.

#### What tests does this PR have?
I've added a test to check that a spread prop will be passed through.

#### How can this be tested?
run the docs and check that you can add an onClick or equivalent to the tile.

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/pBj0EoGSYjGms/giphy.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.