### PR TITLE
APP-269 - Allowing the use of spread for the button component 

### DIFF
--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -2,6 +2,11 @@
 var React = require('react');
 var DataAttributesMixin = require('react-data-attributes-mixin');
 var classNames = require('classnames');
+
+var _ = {
+  omit: require('lodash/object/omit')
+};
+
 module.exports = React.createClass({
 
   mixins: [DataAttributesMixin],
@@ -24,13 +29,9 @@ module.exports = React.createClass({
   },
 
   renderAnchor: function() {
-    var props = {
-      id: this.props.id,
-      className: classNames('component-button', this.props.size, this.props.purpose),
-      href: this.props.href,
-      target: this.props.target,
-      onClick: this.props.handleClick
-    };
+    const props = _.omit(this.props, 'children');
+    props.className = classNames('component-button', this.props.size, this.props.purpose);
+
     var dataAttributes = this.getDataAttributesFromProps();
 
     return (
@@ -41,13 +42,9 @@ module.exports = React.createClass({
   },
 
   renderButton: function() {
-    var props = {
-      id: this.props.id,
-      className: classNames('component-button', this.props.size, this.props.purpose),
-      disabled: this.props.disabled,
-      type: this.props.type,
-      onClick: this.props.handleClick
-    };
+    const props = _.omit(this.props, 'children');
+    props.className = classNames('component-button', this.props.size, this.props.purpose);
+
     var dataAttributes = this.getDataAttributesFromProps();
 
     return (

--- a/test/components/button-test.jsx
+++ b/test/components/button-test.jsx
@@ -2,6 +2,7 @@
 var React = require('react');
 var TestUtils = require('react-addons-test-utils');
 var assert = require('chai').assert;
+var sinon = require('sinon');
 var ButtonView = require('../../src/components/button/button.jsx');
 
 describe('ButtonComponent', function() {
@@ -82,6 +83,18 @@ describe('ButtonComponent', function() {
 
     var renderedButton = TestUtils.findRenderedDOMComponentWithClass(buttonWithID, 'component-button');
     assert.equal(renderedButton.id, 'my-id');
+  });
+
+  it('should render any extra props passed to it', function() {
+    const onMouseOverHandler = sinon.stub();
+
+    var button = TestUtils.renderIntoDocument(
+      <ButtonView onMouseOver={onMouseOverHandler}>Book Now</ButtonView>
+    );
+
+    var renderedButton = TestUtils.findRenderedDOMComponentWithClass(button, 'component-button');
+    TestUtils.Simulate.mouseOver(renderedButton);
+    assert(onMouseOverHandler.called);
   });
 
 });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This PR changes the button component so that you can pass in any prop and it will apply it to the button. 

#### What tests does this PR have?

A new tests to cover adding a unspecified prop to the button

#### How can this be tested?

Pull the branch down and check the buttons still look the same as live. 
click the show code section underneath a button and add the following code to to a button:

`onMouseOver={function(){alert('Hello');}}`

Then mouse over the button you should see an alert appear.

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?
![](https://media.giphy.com/media/l4HohVwFLzHKcwa6A/giphy.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2**
- [ ] :+1:

**Review 3**
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.