### PR TITLE
Add fallback for any apps still using handleClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.2.1 2016-06-22
+- Adding legacy fallback for handleClick on Button component
+- Regression test added
+
 ### 2.2.0 2016-06-22
 - Adding spread operator to Button component
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/ui-toolkit",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "UI Toolkit",
   "license": "MIT",
   "main": "index.js",

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -4,6 +4,7 @@ var DataAttributesMixin = require('react-data-attributes-mixin');
 var classNames = require('classnames');
 
 var _ = {
+  extend: require('lodash/object/extend'),
   omit: require('lodash/object/omit')
 };
 
@@ -24,34 +25,20 @@ module.exports = React.createClass({
     id: React.PropTypes.string
   },
 
-  render: function() {
-    return this.props.href ? this.renderAnchor() : this.renderButton();
-  },
-
-  renderAnchor: function() {
-    const props = _.omit(this.props, 'children');
+  _getProps() {
+    const props = _.omit(this.props, ['data', 'size', 'purpose']);
     props.className = classNames('component-button', this.props.size, this.props.purpose);
 
-    var dataAttributes = this.getDataAttributesFromProps();
+    // this is for legacy usage whilst we deprepecate handleClick
+    if (!props.onClick && props.handleClick) {
+      props.onClick = props.handleClick
+    }
 
-    return (
-      <a {...props} {...dataAttributes}>
-        {this.props.children}
-      </a>
-    );
+    return _.extend({}, props, this.getDataAttributesFromProps());
   },
 
-  renderButton: function() {
-    const props = _.omit(this.props, 'children');
-    props.className = classNames('component-button', this.props.size, this.props.purpose);
-
-    var dataAttributes = this.getDataAttributesFromProps();
-
-    return (
-      <button {...props} {...dataAttributes}>
-        {this.props.children}
-      </button>
-    );
+  render() {
+    return this.props.href ? <a {...this._getProps()} /> : <button {...this._getProps()} />;
   }
 
 });

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -31,7 +31,7 @@ module.exports = React.createClass({
 
     // this is for legacy usage whilst we deprepecate handleClick
     if (!props.onClick && props.handleClick) {
-      props.onClick = props.handleClick
+      props.onClick = props.handleClick;
     }
 
     return _.extend({}, props, this.getDataAttributesFromProps());

--- a/test/components/button-test.jsx
+++ b/test/components/button-test.jsx
@@ -97,4 +97,33 @@ describe('ButtonComponent', function() {
     assert(onMouseOverHandler.called);
   });
 
+  context('click events', function() {
+
+    it('should add click event when onClick passed to it', function() {
+      const onClick = sinon.stub();
+
+      var button = TestUtils.renderIntoDocument(
+        <ButtonView onClick={onClick}>Book Now</ButtonView>
+      );
+
+      var renderedButton = TestUtils.findRenderedDOMComponentWithClass(button, 'component-button');
+      TestUtils.Simulate.click(renderedButton);
+      assert(onClick.called);
+    });
+
+    it('should add click event when legacy handleClick passed to it', function() {
+      const handleClick = sinon.stub();
+
+      var button = TestUtils.renderIntoDocument(
+        <ButtonView handleClick={handleClick}>Book Now</ButtonView>
+      );
+
+      var renderedButton = TestUtils.findRenderedDOMComponentWithClass(button, 'component-button');
+      TestUtils.Simulate.click(renderedButton);
+      assert(handleClick.called);
+    })
+
+  });
+
+
 });

--- a/test/components/button-test.jsx
+++ b/test/components/button-test.jsx
@@ -121,7 +121,7 @@ describe('ButtonComponent', function() {
       var renderedButton = TestUtils.findRenderedDOMComponentWithClass(button, 'component-button');
       TestUtils.Simulate.click(renderedButton);
       assert(handleClick.called);
-    })
+    });
 
   });
 


### PR DESCRIPTION
#### What does this PR do? (please provide any background)


#### What tests does this PR have?
Add test for onClick and regression test for handleClick.

#### How can this be tested?
Fireup any tripapp using master (local, staging or production)
Make a carpark search for LGW and on availability select a non-flexible product
No upsell modal will fire

On your local machine pull this branch
On your local tripapp npm link your local ui-toolkit ( probably `npm link ../ui-toolkit` )
Fire up tripapp and do the same search.
An upsell modal should now fire

#### Screenshots / Screencast


#### What gif best describes how you feel about this work?
![](http://i.giphy.com/An4MkAbxeiyqY.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2**
- [x] :+1:

**Review 3**
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.