### PR TITLE
Ensure es6 shorthand funcs are properly transpiled

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["react"]
+  "presets": ["es2015", "react"]
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",
+    "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-runtime": "^6.11.6",
     "babelify": "^7.3.0",


### PR DESCRIPTION
Fixes a small boo-boo with the v3.0.0 release. The upgrade to babel 6 didn't include the es2015 'preset' which transpiles source to es5. This means that the JSX code was transpiled but constructs like the shorthand method syntax `{ myFunc() {} }` wasn't. The result is that the toolkit with v3.0.0 can't be used in es5 projects without further transpilation.

This works fine in the project itself and fine in other projects, but not when passed through es5 only tools like uglify.

This change can be tested by running `npm run build` and checking that the produced file at `dist/components/button/index.js` is valid es5. I.e. `_getProps: function _getProps() {` not `_getProps() {`.