### PR TITLE
BOOK-2517 Button component to accept multiple class names

### DIFF
--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -15,7 +15,15 @@ module.exports = React.createClass({
   propTypes: {
     children: React.PropTypes.any,
     purpose: React.PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
-    size: React.PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large', 'block']),
+    size: function(props, propName, componentName) {
+      // expects a string with any combination of the following class names
+      const pattern = /^(default|small|medium|large|extra-large|block|\s)*$/;
+      if (props[propName] && !pattern.test(props[propName])) {
+        return new Error('Invalid prop ' + propName + ' supplied to ' +
+          componentName + '. Validation failed.');
+      }
+      return undefined;
+    },
     disabled: React.PropTypes.bool,
     href: React.PropTypes.string,
     type: React.PropTypes.string,

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -19,7 +19,7 @@ module.exports = React.createClass({
       // expects a string with any combination of the following class names
       const propValue = props[propName];
       const expectedValues = ['default', 'small', 'medium', 'large', 'extra-large', 'block'];
-      const pattern = new RegExp('^(' + expectedValues.join('|') + '|\s)*$');
+      const pattern = new RegExp('^(' + expectedValues.join('|') + '|\\s)*$');
       if (propValue && !pattern.test(propValue)) {
         return new Error('Invalid prop `' + propName + '` of value `' + propValue
           + '` supplied to `' + componentName + '`, expected any of ["'

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -17,10 +17,13 @@ module.exports = React.createClass({
     purpose: React.PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
     size: function(props, propName, componentName) {
       // expects a string with any combination of the following class names
-      const pattern = /^(default|small|medium|large|extra-large|block|\s)*$/;
-      if (props[propName] && !pattern.test(props[propName])) {
-        return new Error('Invalid prop ' + propName + ' supplied to ' +
-          componentName + '. Validation failed.');
+      const propValue = props[propName];
+      const expectedValues = ['default', 'small', 'medium', 'large', 'extra-large', 'block'];
+      const pattern = new RegExp('^(' + expectedValues.join('|') + '|\s)*$');
+      if (propValue && !pattern.test(propValue)) {
+        return new Error('Invalid prop `' + propName + '` of value `' + propValue
+          + '` supplied to `' + componentName + '`, expected any of ["'
+          + expectedValues.join('", "') + '"]. Validation failed.');
       }
       return undefined;
     },


### PR DESCRIPTION
The `size` prop of the `Button` component used to only accept one class name. There are cases when we need a combination of a size and the `block` modifier.

With this change the component will accept 0 or more pre-defined, space-separated class names. In case of an invalid value the error will look like this:
> Warning: Failed propType: Invalid prop `size` of value `small smallish block` supplied to `exports`, expected any of ["default", "small", "medium", "large", "extra-large", "block"]. Validation failed. Check the render method of `CarparkTile`.