### PR TITLE
MOB-77 Rating component: add key props to the rating icons

### DIFF
--- a/src/components/rating/rating.jsx
+++ b/src/components/rating/rating.jsx
@@ -13,13 +13,21 @@ module.exports = React.createClass({
     var $rating = [];
     var $blankRating = [];
 
+    var ratingIcon = this.props.children || <span className="rating-icon" />;
     for (var i = 0; i < this.props.rating; i++) {
-      $rating.push( this.props.children ? this.props.children : <span className="rating-icon" /> );
+      $rating.push(ratingIcon.type
+        ? React.cloneElement(ratingIcon, { key: i })
+        : ratingIcon
+      );
     }
 
-    if (this.props.outOf && this.props.blankIcon) {
+    var blankRatingIcon = this.props.blankIcon;
+    if (this.props.outOf && blankRatingIcon) {
       for (var j = 0; j < ( this.props.outOf - this.props.rating ); j++) {
-        $blankRating.push( this.props.blankIcon );
+        $blankRating.push(blankRatingIcon.type
+          ? React.cloneElement(blankRatingIcon, { key: j })
+          : blankRatingIcon
+        );
       }
     }
 

--- a/test/components/rating-test.jsx
+++ b/test/components/rating-test.jsx
@@ -23,10 +23,28 @@ describe('Rating', function() {
       });
     });
 
+    describe('with a child prop that is a component', function() {
+      it('is an element', function() {
+        var component = TestUtils.renderIntoDocument(
+          <Rating rating={4}><div>X</div></Rating>
+        );
+        assert.isDefined(component);
+      });
+    });
+
     describe('with a blank icon prop', function() {
       it('is an element', function() {
         var component = TestUtils.renderIntoDocument(
           <Rating rating={4} outOf={5} blankIcon="X" />
+        );
+        assert.isDefined(component);
+      });
+    });
+
+    describe('with a blank icon prop that is a component', function() {
+      it('is an element', function() {
+        var component = TestUtils.renderIntoDocument(
+          <Rating rating={4} outOf={5} blankIcon={<div>X</div>} />
         );
         assert.isDefined(component);
       });


### PR DESCRIPTION
The Rating component did not add key props to its icons. This would cause JS errors in the console at a dev environment. This PR fixes this issue.