### PR TITLE
Convert functional components from createClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.2.0 - 2017-11-09
+- Make components not using mixins or state functional
+
 ### 3.1.1 - 2017-11-08
 - Fix build error where countdown component libs weren't transpiled
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/ui-toolkit",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "UI Toolkit",
   "license": "MIT",
   "main": "index.js",

--- a/src/components/alert/alert.jsx
+++ b/src/components/alert/alert.jsx
@@ -4,22 +4,23 @@ const React = require('react')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const Alert = ({
+  title,
+  children,
+  purpose,
+  size
+}) => (
+  <div className={classNames('component-alert', size, purpose)} role='alert'>
+    {title ? <h4>{title}</h4> : ''}
+    <p>{children}</p>
+  </div>
+)
 
-  propTypes: {
-    title: PropTypes.string,
-    children: PropTypes.any,
-    purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
-    size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large'])
-  },
+Alert.propTypes = {
+  title: PropTypes.string,
+  children: PropTypes.any,
+  purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
+  size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large'])
+}
 
-  render: function () {
-    const classes = classNames('component-alert', this.props.size, this.props.purpose)
-    return (
-      <div className={classes} role='alert'>
-        {this.props.title ? <h4>{this.props.title}</h4> : ''}
-        <p>{this.props.children}</p>
-      </div>
-    )
-  }
-})
+module.exports = Alert

--- a/src/components/button-dropdown/button-dropdown.jsx
+++ b/src/components/button-dropdown/button-dropdown.jsx
@@ -4,19 +4,18 @@ const React = require('react')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const ButtonDropdown = ({
+  children,
+  position
+}) => (
+  <div className={classNames('component-button-dropdown', position)}>
+    {children}
+  </div>
+)
 
-  propTypes: {
-    children: PropTypes.any,
-    position: PropTypes.oneOf(['top', 'bottom'])
-  },
+ButtonDropdown.propTypes = {
+  children: PropTypes.any,
+  position: PropTypes.oneOf(['top', 'bottom'])
+}
 
-  render: function () {
-    const classes = classNames('component-button-dropdown', this.props.position)
-    return (
-      <div className={classes}>
-        {this.props.children}
-      </div>
-    )
-  }
-})
+module.exports = ButtonDropdown

--- a/src/components/flag/flag.jsx
+++ b/src/components/flag/flag.jsx
@@ -4,36 +4,37 @@ const React = require('react')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const Flag = ({
+  children,
+  purpose,
+  size,
+  position
+}) => (
+  <span className={classNames('component-flag', size, purpose, position)}>
+    {children}
+  </span>
+)
 
-  propTypes: {
-    children: PropTypes.any,
-    purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
-    size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large']),
-    position: PropTypes.oneOf([
-      'top',
-      'right',
-      'bottom',
-      'left',
-      'top left',
-      'bottom left',
-      'top right',
-      'bottom right',
-      'left top',
-      'left bottom',
-      'right top',
-      'right bottom',
-      'left right',
-      'right left'
-    ])
-  },
+Flag.propTypes = {
+  children: PropTypes.any,
+  purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
+  size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large']),
+  position: PropTypes.oneOf([
+    'top',
+    'right',
+    'bottom',
+    'left',
+    'top left',
+    'bottom left',
+    'top right',
+    'bottom right',
+    'left top',
+    'left bottom',
+    'right top',
+    'right bottom',
+    'left right',
+    'right left'
+  ])
+}
 
-  render: function () {
-    const classes = classNames('component-flag', this.props.size, this.props.purpose, this.props.position)
-    return (
-      <span className={classes}>
-        {this.props.children}
-      </span>
-    )
-  }
-})
+module.exports = Flag

--- a/src/components/icon/icon.jsx
+++ b/src/components/icon/icon.jsx
@@ -3,34 +3,26 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const Icon = ({
+  icon,
+  iconFamily
+}) => {
+  const family = iconFamily === 'font-awesome' ? 'fa' : iconFamily
+  return (
+    <i
+      className={'component-icon ' + family + ' ' + family + '-' + icon}
+      aria-hidden='true'
+    />
+  )
+}
 
-  propTypes: {
-    icon: PropTypes.string.isRequired,
-    iconFamily: PropTypes.oneOf(['font-awesome', 'glyphicon'])
-  },
+Icon.propTypes = {
+  icon: PropTypes.string.isRequired,
+  iconFamily: PropTypes.oneOf(['font-awesome', 'glyphicon'])
+}
 
-  getDefaultProps: function () {
-    return {
-      iconFamily: 'font-awesome'
-    }
-  },
+Icon.defaultProps = {
+  iconFamily: 'font-awesome'
+}
 
-  getIconFamily: function () {
-    let iconFamily = this.props.iconFamily
-    if (this.props.iconFamily === 'font-awesome') {
-      iconFamily = 'fa'
-    }
-    return iconFamily
-  },
-
-  getIcon: function () {
-    return this.getIconFamily() + '-' + this.props.icon
-  },
-
-  render: function () {
-    return (
-      <i className={'component-icon ' + this.getIconFamily() + ' ' + this.getIcon()} aria-hidden='true' />
-    )
-  }
-})
+module.exports = Icon

--- a/src/components/list-description/list-description.jsx
+++ b/src/components/list-description/list-description.jsx
@@ -3,17 +3,16 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const ListDescription = ({
+  children
+}) => (
+  <dd className='component-list-description'>
+    {children}
+  </dd>
+)
 
-  propTypes: {
-    children: PropTypes.any
-  },
+ListDescription.propTypes = {
+  children: PropTypes.any
+}
 
-  render: function () {
-    return (
-      <dd className='component-list-description'>
-        {this.props.children}
-      </dd>
-    )
-  }
-})
+module.exports = ListDescription

--- a/src/components/list-item/list-item.jsx
+++ b/src/components/list-item/list-item.jsx
@@ -3,17 +3,16 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const ListItem = ({
+  children
+}) => (
+  <li className='component-list-item'>
+    {children}
+  </li>
+)
 
-  propTypes: {
-    children: PropTypes.any
-  },
+ListItem.propTypes = {
+  children: PropTypes.any
+}
 
-  render: function () {
-    return (
-      <li className='component-list-item'>
-        {this.props.children}
-      </li>
-    )
-  }
-})
+module.exports = ListItem

--- a/src/components/list-term/list-term.jsx
+++ b/src/components/list-term/list-term.jsx
@@ -3,17 +3,16 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const ListTerm = ({
+  children
+}) => (
+  <dt className='component-list-term'>
+    {children}
+  </dt>
+)
 
-  propTypes: {
-    children: PropTypes.any
-  },
+ListTerm.propTypes = {
+  children: PropTypes.any
+}
 
-  render: function () {
-    return (
-      <dt className='component-list-term'>
-        {this.props.children}
-      </dt>
-    )
-  }
-})
+module.exports = ListTerm

--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -3,37 +3,39 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
-
-  propTypes: {
-    children: PropTypes.any,
-    type: PropTypes.oneOf(['ordered', 'unordered', 'description', 'icon'])
-  },
-
-  render: function () {
-    if (this.props.type === 'ordered') {
-      return (
-        <ol className='component-ordered-list'>
-          {this.props.children}
-        </ol>
-      )
-    } else if (this.props.type === 'icon') {
-      return (
-        <ul className='component-icon-list'>
-          {this.props.children}
-        </ul>
-      )
-    } else if (this.props.type === 'description') {
-      return (
-        <dl className='component-description-list'>
-          {this.props.children}
-        </dl>
-      )
-    }
+const List = ({
+  children,
+  type
+}) => {
+  if (type === 'ordered') {
     return (
-      <ul className='component-unordered-list'>
-        {this.props.children}
+      <ol className='component-ordered-list'>
+        {children}
+      </ol>
+    )
+  } else if (type === 'icon') {
+    return (
+      <ul className='component-icon-list'>
+        {children}
       </ul>
     )
+  } else if (type === 'description') {
+    return (
+      <dl className='component-description-list'>
+        {children}
+      </dl>
+    )
   }
-})
+  return (
+    <ul className='component-unordered-list'>
+      {children}
+    </ul>
+  )
+}
+
+List.propTypes = {
+  children: PropTypes.any,
+  type: PropTypes.oneOf(['ordered', 'unordered', 'description', 'icon'])
+}
+
+module.exports = List

--- a/src/components/lozenge/lozenge.jsx
+++ b/src/components/lozenge/lozenge.jsx
@@ -4,21 +4,22 @@ const React = require('react')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
+const Lozenge = ({
+  tip,
+  children,
+  purpose,
+  size
+}) => (
+  <span className={classNames('component-lozenge', size, purpose)} title={tip}>
+    {children}
+  </span>
+)
 
-  propTypes: {
-    tip: PropTypes.string,
-    children: PropTypes.any,
-    purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
-    size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large', 'block'])
-  },
+Lozenge.propTypes = {
+  tip: PropTypes.string,
+  children: PropTypes.any,
+  purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
+  size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large', 'block'])
+}
 
-  render: function () {
-    const classes = classNames('component-lozenge', this.props.size, this.props.purpose)
-    return (
-      <span className={classes} title={this.props.tip}>
-        {this.props.children}
-      </span>
-    )
-  }
-})
+module.exports = Lozenge

--- a/src/components/payment-card/payment-card.jsx
+++ b/src/components/payment-card/payment-card.jsx
@@ -4,24 +4,25 @@ const React = require('react')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
-  propTypes: {
-    size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large']),
-    type: PropTypes.oneOf(['amazon', 'amex', 'apple', 'cirrus', 'delta', 'directdebit', 'discover', 'electron', 'google', 'maestro', 'mastercard', 'paym', 'paypal', 'sage', 'sepa', 'solo', 'switch', 'ukash', 'visa', 'visadebit', 'westernunion']),
-    className: PropTypes.string
-  },
+const PaymentCard = (props) => {
+  const { size, type, className } = props
+  const classes = classNames('component-payment-card', type, size, className)
 
-  render: function () {
-    const classes = classNames('component-payment-card', this.props.type, this.props.size, this.props.className)
-
-    const spreadProps = {}
-    for (const key in this.props) {
-      if (['type', 'size', 'className', 'children'].indexOf(key) !== -1) continue
-      spreadProps[key] = this.props[key]
-    }
-
-    return (
-      <div className={classes} {...spreadProps} />
-    )
+  const spreadProps = {}
+  for (const key in props) {
+    if (['type', 'size', 'className', 'children'].indexOf(key) !== -1) continue
+    spreadProps[key] = props[key]
   }
-})
+
+  return (
+    <div className={classes} {...spreadProps} />
+  )
+}
+
+PaymentCard.propTypes = {
+  size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large']),
+  type: PropTypes.oneOf(['amazon', 'amex', 'apple', 'cirrus', 'delta', 'directdebit', 'discover', 'electron', 'google', 'maestro', 'mastercard', 'paym', 'paypal', 'sage', 'sepa', 'solo', 'switch', 'ukash', 'visa', 'visadebit', 'westernunion']),
+  className: PropTypes.string
+}
+
+module.exports = PaymentCard

--- a/src/components/quote/quote.jsx
+++ b/src/components/quote/quote.jsx
@@ -4,42 +4,50 @@ const React = require('react')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
-
-  propTypes: {
-    children: PropTypes.any,
-    cite: PropTypes.string,
-    author: PropTypes.string,
-    role: PropTypes.string,
-    purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
-    size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large']),
-    orientation: PropTypes.oneOf(['default', 'horizontal', 'vertical']),
-    type: PropTypes.oneOf(['block', 'inline'])
-  },
-
-  render: function () {
-    const classes = classNames('component-quote', this.props.size, this.props.purpose, this.props.type)
-    if (this.props.type === 'inline') {
-      return (
-        <q className={classes} cite={this.props.cite} itemScope itemType='http://schema.org/CreativeWork' itemProp='text'>
-          {this.props.children}
-          {(this.props.cite) ? <meta itemProp='citation' content={this.props.cite} /> : null}
-          <span itemProp='author' itemScope itemType='http://schema.org/Person'>
-            <meta itemProp='name' content={this.props.author} />
-            <meta itemProp='jobTitle' content={this.props.role} />
-          </span>
-        </q>
-      )
-    }
+const Quote = ({
+  children,
+  cite,
+  author,
+  role,
+  purpose,
+  size,
+  orientation,
+  type
+}) => {
+  const classes = classNames('component-quote', size, purpose, type)
+  if (type === 'inline') {
     return (
-      <blockquote className={classes} itemScope itemType='http://schema.org/CreativeWork'>
-        <p itemProp='text'>{this.props.children}</p>
-        <footer itemProp='author' itemScope itemType='http://schema.org/Person'>
-          <span itemProp='name'>{this.props.author}</span>
-          <small itemProp='jobTitle'>{this.props.role}</small>
-          {(this.props.cite) ? <cite itemProp='citation'>{this.props.cite}</cite> : null}
-        </footer>
-      </blockquote>
+      <q className={classes} cite={cite} itemScope itemType='http://schema.org/CreativeWork' itemProp='text'>
+        {children}
+        {(cite) ? <meta itemProp='citation' content={cite} /> : null}
+        <span itemProp='author' itemScope itemType='http://schema.org/Person'>
+          <meta itemProp='name' content={author} />
+          <meta itemProp='jobTitle' content={role} />
+        </span>
+      </q>
     )
   }
-})
+  return (
+    <blockquote className={classes} itemScope itemType='http://schema.org/CreativeWork'>
+      <p itemProp='text'>{children}</p>
+      <footer itemProp='author' itemScope itemType='http://schema.org/Person'>
+        <span itemProp='name'>{author}</span>
+        <small itemProp='jobTitle'>{role}</small>
+        {(cite) ? <cite itemProp='citation'>{cite}</cite> : null}
+      </footer>
+    </blockquote>
+  )
+}
+
+Quote.propTypes = {
+  children: PropTypes.any,
+  cite: PropTypes.string,
+  author: PropTypes.string,
+  role: PropTypes.string,
+  purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
+  size: PropTypes.oneOf(['default', 'small', 'medium', 'large', 'extra-large']),
+  orientation: PropTypes.oneOf(['default', 'horizontal', 'vertical']),
+  type: PropTypes.oneOf(['block', 'inline'])
+}
+
+module.exports = Quote

--- a/src/components/rating/rating.jsx
+++ b/src/components/rating/rating.jsx
@@ -3,41 +3,46 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
-  propTypes: {
-    children: PropTypes.any,
-    rating: PropTypes.number.isRequired,
-    outOf: PropTypes.number,
-    blankIcon: PropTypes.node
-  },
+const Rating = ({
+  children,
+  rating,
+  outOf,
+  blankIcon
+}) => {
+  const $rating = []
+  const $blankRating = []
 
-  render: function () {
-    const $rating = []
-    const $blankRating = []
-
-    const ratingIcon = this.props.children || <span className='rating-icon' />
-    for (let i = 0; i < this.props.rating; i++) {
-      $rating.push(ratingIcon.type
-        ? React.cloneElement(ratingIcon, { key: i })
-        : ratingIcon
-      )
-    }
-
-    const blankRatingIcon = this.props.blankIcon
-    if (this.props.outOf && blankRatingIcon) {
-      for (let j = 0; j < (this.props.outOf - this.props.rating); j++) {
-        $blankRating.push(blankRatingIcon.type
-          ? React.cloneElement(blankRatingIcon, { key: j })
-          : blankRatingIcon
-        )
-      }
-    }
-
-    return (
-      <div className='ui-component-rating'>
-        {$rating}
-        {$blankRating}
-      </div>
+  const ratingIcon = children || <span className='rating-icon' />
+  for (let i = 0; i < rating; i++) {
+    $rating.push(ratingIcon.type
+      ? React.cloneElement(ratingIcon, { key: i })
+      : ratingIcon
     )
   }
-})
+
+  const blankRatingIcon = blankIcon
+  if (outOf && blankRatingIcon) {
+    for (let j = 0; j < (outOf - rating); j++) {
+      $blankRating.push(blankRatingIcon.type
+        ? React.cloneElement(blankRatingIcon, { key: j })
+        : blankRatingIcon
+      )
+    }
+  }
+
+  return (
+    <div className='ui-component-rating'>
+      {$rating}
+      {$blankRating}
+    </div>
+  )
+}
+
+Rating.propTypes = {
+  children: PropTypes.any,
+  rating: PropTypes.number.isRequired,
+  outOf: PropTypes.number,
+  blankIcon: PropTypes.node
+}
+
+module.exports = Rating

--- a/src/components/reviews/reviews.jsx
+++ b/src/components/reviews/reviews.jsx
@@ -3,18 +3,20 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
-  propTypes: {
-    reviewPercentage: PropTypes.number.isRequired,
-    reviewCount: PropTypes.number.isRequired
-  },
-  render: function () {
-    return (
-      <div itemProp='aggregateRating' itemScope itemType='http://schema.org/AggregateRating' className='ui-component-reviews'>
-        <meta itemProp='bestRating' content='100' />
-        <div><span itemProp='ratingValue'>{ this.props.reviewPercentage }</span>% would book again</div>
-        <div><span itemProp='reviewCount'>({ this.props.reviewCount }</span> <a title='Customer reviews'>Reviews</a>)</div>
-      </div>
-    )
-  }
-})
+const Reviews = ({
+  reviewPercentage,
+  reviewCount
+}) => (
+  <div itemProp='aggregateRating' itemScope itemType='http://schema.org/AggregateRating' className='ui-component-reviews'>
+    <meta itemProp='bestRating' content='100' />
+    <div><span itemProp='ratingValue'>{reviewPercentage}</span>% would book again</div>
+    <div><span itemProp='reviewCount'>({reviewCount}</span> <a title='Customer reviews'>Reviews</a>)</div>
+  </div>
+)
+
+Reviews.propTypes = {
+  reviewPercentage: PropTypes.number.isRequired,
+  reviewCount: PropTypes.number.isRequired
+}
+
+module.exports = Reviews

--- a/src/components/tile/tile.jsx
+++ b/src/components/tile/tile.jsx
@@ -7,23 +7,22 @@ const _ = {
   omit: require('lodash/omit')
 }
 
-module.exports = React.createClass({
-  propTypes: {
-    children: PropTypes.any,
-    image: PropTypes.object.isRequired
-  },
-
-  render: function () {
-    const { image, children } = this.props
-    const tileProps = _.omit(this.props, 'image', 'children')
-
-    return (
-      <div className='component-tile' {...tileProps}>
-        <Image {...image} />
-        <div className='component-tile-block'>
-          {children}
-        </div>
+const Tile = (props) => {
+  const { children, image } = props
+  const tileProps = _.omit(props, 'image', 'children')
+  return (
+    <div className='component-tile' {...tileProps}>
+      <Image {...image} />
+      <div className='component-tile-block'>
+        {children}
       </div>
-    )
-  }
-})
+    </div>
+  )
+}
+
+Tile.propTypes = {
+  children: PropTypes.any,
+  image: PropTypes.object.isRequired
+}
+
+module.exports = Tile

--- a/src/components/weather/weather.jsx
+++ b/src/components/weather/weather.jsx
@@ -4,39 +4,46 @@ const React = require('react')
 const PropTypes = require('prop-types')
 const moment = require('moment')
 
-module.exports = React.createClass({
+const EXPECTED_FORMAT = ['YYYY-MM-DD', 'YYYY-MM-DDTHH:mm']
+const UNIT_NAMES = {
+  'C': 'Degrees Celsuis',
+  'F': 'Degrees Farenheit',
+  'K': 'Kelvin',
+  'R': 'Degrees Rankine'
+}
 
-  propTypes: {
-    format: PropTypes.string,
-    type: PropTypes.oneOf(['cloudy', 'fog', 'hail', 'heavy-rain', 'heavy-snow', 'light-rain', 'light-snow', 'night-clear', 'night-partly-cloudy', 'partly-cloudy', 'storm', 'sunny', 'windy']).isRequired,
-    temperature: PropTypes.number,
-    date: PropTypes.string,
-    unit: PropTypes.oneOf(['C', 'F', 'K', 'R'])
-  },
+const Weather = ({
+  format,
+  type,
+  temperature,
+  date,
+  unit
+}) => {
+  const displayFormat = format || 'ddd'
+  const displayUnit = unit === 'K' ? unit : '°' + unit
+  const unitName = UNIT_NAMES[unit]
 
-  render: function () {
-    const expectedFormat = ['YYYY-MM-DD', 'YYYY-MM-DDTHH:mm']
-    const displayFormat = this.props.format || 'ddd'
-    const date = this.props.date
-    let unit = this.props.unit
-    if (this.props.unit !== 'K') {
-      unit = '°' + unit
-    }
+  return (
+    <div className='component-weather'>
+      <div className={type}><span>{type}</span></div>
+      {(temperature || temperature === 0)
+        ? <div>{temperature}<abbr title={unitName}>{displayUnit}</abbr></div>
+        : null
+      }
+      {date
+        ? <div>{moment(date, EXPECTED_FORMAT, true).format(displayFormat)}</div>
+        : null
+      }
+    </div>
+  )
+}
 
-    const unitNames = {
-      'C': 'Degrees Celsuis',
-      'F': 'Degrees Farenheit',
-      'K': 'Kelvin',
-      'R': 'Degrees Rankine'
-    }
-    const unitName = unitNames[this.props.unit]
+Weather.propTypes = {
+  format: PropTypes.string,
+  type: PropTypes.oneOf(['cloudy', 'fog', 'hail', 'heavy-rain', 'heavy-snow', 'light-rain', 'light-snow', 'night-clear', 'night-partly-cloudy', 'partly-cloudy', 'storm', 'sunny', 'windy']).isRequired,
+  temperature: PropTypes.number,
+  date: PropTypes.string,
+  unit: PropTypes.oneOf(['C', 'F', 'K', 'R'])
+}
 
-    return (
-      <div className='component-weather'>
-        <div className={this.props.type}><span>{this.props.type}</span></div>
-        {(this.props.temperature || this.props.temperature === 0) ? <div>{this.props.temperature}<abbr title={unitName}>{unit}</abbr></div> : null}
-        {(this.props.date) ? <div>{moment(date, expectedFormat, true).format(displayFormat)}</div> : null}
-      </div>
-    )
-  }
-})
+module.exports = Weather

--- a/test/components/alert-test.jsx
+++ b/test/components/alert-test.jsx
@@ -1,13 +1,15 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const AlertComponent = require('../../src/components/alert/alert.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('AlertComponent', function () {
   it('should render an Alert', function () {
     const alert = TestUtils.renderIntoDocument(
-      <AlertComponent>I am content</AlertComponent>
+      <Wrapper><AlertComponent>I am content</AlertComponent></Wrapper>
     )
 
     const renderedAlert = TestUtils.findRenderedDOMComponentWithClass(alert, 'component-alert')
@@ -16,7 +18,7 @@ describe('AlertComponent', function () {
 
   it('should render an alert without a H4 if title is no passed in', function () {
     const successAlert = TestUtils.renderIntoDocument(
-      <AlertComponent purpose='success' title='title'>You have been successful</AlertComponent>
+      <Wrapper><AlertComponent purpose='success' title='title'>You have been successful</AlertComponent></Wrapper>
     )
     const h4 = TestUtils.scryRenderedDOMComponentsWithTag(successAlert, 'h4')
     assert.equal(h4.length, 1)
@@ -24,7 +26,7 @@ describe('AlertComponent', function () {
 
   it('should render an alert with a H4 if title is passed in', function () {
     const successAlert = TestUtils.renderIntoDocument(
-      <AlertComponent purpose='success'>You have been successful</AlertComponent>
+      <Wrapper><AlertComponent purpose='success'>You have been successful</AlertComponent></Wrapper>
     )
     const h4 = TestUtils.scryRenderedDOMComponentsWithTag(successAlert, 'h4')
     assert.equal(h4.length, 0)
@@ -32,7 +34,7 @@ describe('AlertComponent', function () {
 
   it('should render a success alert', function () {
     const successAlert = TestUtils.renderIntoDocument(
-      <AlertComponent purpose='success'>You have been successful</AlertComponent>
+      <Wrapper><AlertComponent purpose='success'>You have been successful</AlertComponent></Wrapper>
     )
 
     const renderedAlert = TestUtils.findRenderedDOMComponentWithClass(successAlert, 'success')
@@ -41,7 +43,7 @@ describe('AlertComponent', function () {
 
   it('should render a danger alert', function () {
     const dangerAlert = TestUtils.renderIntoDocument(
-      <AlertComponent purpose='danger'>This is dangerous</AlertComponent>
+      <Wrapper><AlertComponent purpose='danger'>This is dangerous</AlertComponent></Wrapper>
     )
 
     const renderedAlert = TestUtils.findRenderedDOMComponentWithClass(dangerAlert, 'danger')
@@ -50,7 +52,7 @@ describe('AlertComponent', function () {
 
   it('should render a info alert', function () {
     const infoAlert = TestUtils.renderIntoDocument(
-      <AlertComponent purpose='info'>This is information</AlertComponent>
+      <Wrapper><AlertComponent purpose='info'>This is information</AlertComponent></Wrapper>
     )
 
     const renderedAlert = TestUtils.findRenderedDOMComponentWithClass(infoAlert, 'info')
@@ -59,7 +61,7 @@ describe('AlertComponent', function () {
 
   it('should render a warning alert', function () {
     const warningAlert = TestUtils.renderIntoDocument(
-      <AlertComponent purpose='warning'>You have been warned</AlertComponent>
+      <Wrapper><AlertComponent purpose='warning'>You have been warned</AlertComponent></Wrapper>
     )
 
     const renderedAlert = TestUtils.findRenderedDOMComponentWithClass(warningAlert, 'warning')
@@ -68,7 +70,7 @@ describe('AlertComponent', function () {
 
   it('should render a large default alert', function () {
     const largeAlert = TestUtils.renderIntoDocument(
-      <AlertComponent size='large'>I am large</AlertComponent>
+      <Wrapper><AlertComponent size='large'>I am large</AlertComponent></Wrapper>
     )
 
     const renderedAlert = TestUtils.findRenderedDOMComponentWithClass(largeAlert, 'large')
@@ -77,7 +79,7 @@ describe('AlertComponent', function () {
 
   it('should render an alert with a header', function () {
     const alert = TestUtils.renderIntoDocument(
-      <AlertComponent title='Header' />
+      <Wrapper><AlertComponent title='Header' /></Wrapper>
     )
 
     const renderedAlert = TestUtils.findRenderedDOMComponentWithClass(alert, 'component-alert')

--- a/test/components/anchor-test.jsx
+++ b/test/components/anchor-test.jsx
@@ -1,4 +1,5 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const sinon = require('sinon')

--- a/test/components/basket-item-test.jsx
+++ b/test/components/basket-item-test.jsx
@@ -1,4 +1,5 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert

--- a/test/components/button-dropdown-test.jsx
+++ b/test/components/button-dropdown-test.jsx
@@ -1,9 +1,11 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const expect = require('chai')
 .use(require('dirty-chai')).expect
 const ButtonDropdown = require('../../src/components/button-dropdown/button-dropdown.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('ButtonDropdown', function () {
   let props
@@ -14,40 +16,42 @@ describe('ButtonDropdown', function () {
   })
 
   it('should be a valid react component', function () {
-    expect(TestUtils.isElement(<ButtonDropdown />)).to.be.true()
+    expect(TestUtils.isElement(<Wrapper><ButtonDropdown /></Wrapper>)).to.be.true()
   })
 
   it('should be a valid dom component', function () {
-    const buttonDropdown = TestUtils.renderIntoDocument(<ButtonDropdown />)
+    const buttonDropdown = TestUtils.renderIntoDocument(<Wrapper><ButtonDropdown /></Wrapper>)
     const renderedButtonComponent = TestUtils.findRenderedDOMComponentWithClass(buttonDropdown, 'component-button-dropdown')
     expect(TestUtils.isDOMComponent(renderedButtonComponent)).to.be.true()
   })
 
   it('should be able to have position of top passed to the component', function () {
     props.position = 'top'
-    const buttonDropdown = TestUtils.renderIntoDocument(<ButtonDropdown {...props} />)
+    const buttonDropdown = TestUtils.renderIntoDocument(<Wrapper><ButtonDropdown {...props} /></Wrapper>)
     expect(TestUtils.findRenderedDOMComponentWithClass(buttonDropdown, 'top')).to.be.ok()
   })
 
   it('should be able to have position of bottom passed to the component', function () {
     props.position = 'bottom'
-    const buttonDropdown = TestUtils.renderIntoDocument(<ButtonDropdown {...props} />)
+    const buttonDropdown = TestUtils.renderIntoDocument(<Wrapper><ButtonDropdown {...props} /></Wrapper>)
     expect(TestUtils.findRenderedDOMComponentWithClass(buttonDropdown, 'bottom')).to.be.ok()
   })
 
   it('should be able to not pass any position as it isnt required', function () {
-    const buttonDropdown = TestUtils.renderIntoDocument(<ButtonDropdown />)
+    const buttonDropdown = TestUtils.renderIntoDocument(<Wrapper><ButtonDropdown /></Wrapper>)
     expect(TestUtils.findRenderedDOMComponentWithClass(buttonDropdown, 'component-button-dropdown')).to.be.ok()
   })
 
   context('when rendering into document', function () {
     it('should be able to take a number of children', function () {
       const buttonDropdown = TestUtils.renderIntoDocument(
-        <ButtonDropdown>
-          <div>
-            <button />
-          </div>
-        </ButtonDropdown>
+        <Wrapper>
+          <ButtonDropdown>
+            <div>
+              <button />
+            </div>
+          </ButtonDropdown>
+        </Wrapper>
       )
       expect(buttonDropdown).to.be.ok()
     })

--- a/test/components/button-test.jsx
+++ b/test/components/button-test.jsx
@@ -1,4 +1,5 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert

--- a/test/components/countdown-test.js
+++ b/test/components/countdown-test.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const countdown = require('../../src/components/countdown/lib/countdown')
 const moment = require('moment')
 const assert = require('chai').assert

--- a/test/components/countdownManager-test.js
+++ b/test/components/countdownManager-test.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const CountdownManager = require('../../src/components/countdown/lib/countdownManager')
 const countdown = require('../../src/components/countdown/lib/countdown')
 const assert = require('chai').assert

--- a/test/components/flag-test.jsx
+++ b/test/components/flag-test.jsx
@@ -1,13 +1,15 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const FlagComponent = require('../../src/components/flag/flag.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('FlagComponent', function () {
   it('should render a Flag', function () {
     const flag = TestUtils.renderIntoDocument(
-      <FlagComponent>Special Offer</FlagComponent>
+      <Wrapper><FlagComponent>Special Offer</FlagComponent></Wrapper>
     )
 
     const renderedFlag = TestUtils.findRenderedDOMComponentWithClass(flag, 'component-flag')
@@ -16,7 +18,7 @@ describe('FlagComponent', function () {
 
   it('should render a default flag', function () {
     const defaultFlag = TestUtils.renderIntoDocument(
-      <FlagComponent size='default'>Special Offer</FlagComponent>
+      <Wrapper><FlagComponent size='default'>Special Offer</FlagComponent></Wrapper>
     )
 
     const renderedFlag = TestUtils.findRenderedDOMComponentWithClass(defaultFlag, 'default')
@@ -25,7 +27,7 @@ describe('FlagComponent', function () {
 
   it('should render a danger flag', function () {
     const dangerFlag = TestUtils.renderIntoDocument(
-      <FlagComponent purpose='danger'>Special Offer</FlagComponent>
+      <Wrapper><FlagComponent purpose='danger'>Special Offer</FlagComponent></Wrapper>
     )
 
     const renderedFlag = TestUtils.findRenderedDOMComponentWithClass(dangerFlag, 'danger')
@@ -34,7 +36,7 @@ describe('FlagComponent', function () {
 
   it('should render a medium flag', function () {
     const mediumFlag = TestUtils.renderIntoDocument(
-      <FlagComponent size='medium'>Special Offer</FlagComponent>
+      <Wrapper><FlagComponent size='medium'>Special Offer</FlagComponent></Wrapper>
     )
 
     const renderedFlag = TestUtils.findRenderedDOMComponentWithClass(mediumFlag, 'medium')
@@ -43,7 +45,7 @@ describe('FlagComponent', function () {
 
   it('should render a large flag', function () {
     const largeFlag = TestUtils.renderIntoDocument(
-      <FlagComponent size='large'>Special Offer</FlagComponent>
+      <Wrapper><FlagComponent size='large'>Special Offer</FlagComponent></Wrapper>
     )
 
     const renderedFlag = TestUtils.findRenderedDOMComponentWithClass(largeFlag, 'large')
@@ -52,7 +54,7 @@ describe('FlagComponent', function () {
 
   it('should render a flag on the right', function () {
     const rightFlag = TestUtils.renderIntoDocument(
-      <FlagComponent position='right'>Special Offer</FlagComponent>
+      <Wrapper><FlagComponent position='right'>Special Offer</FlagComponent></Wrapper>
     )
 
     const renderedFlag = TestUtils.findRenderedDOMComponentWithClass(rightFlag, 'right')
@@ -61,7 +63,7 @@ describe('FlagComponent', function () {
 
   it('should render a small secondary right flag', function () {
     const smallSecondaryRightFlag = TestUtils.renderIntoDocument(
-      <FlagComponent size='small' purpose='secondary' position='right'>Book Now</FlagComponent>
+      <Wrapper><FlagComponent size='small' purpose='secondary' position='right'>Book Now</FlagComponent></Wrapper>
     )
 
     const renderedFlag = TestUtils.findRenderedDOMComponentWithClass(smallSecondaryRightFlag, 'small secondary right')

--- a/test/components/image-test.jsx
+++ b/test/components/image-test.jsx
@@ -1,4 +1,5 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert

--- a/test/components/input-test.jsx
+++ b/test/components/input-test.jsx
@@ -1,4 +1,5 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert

--- a/test/components/list-description-test.jsx
+++ b/test/components/list-description-test.jsx
@@ -1,17 +1,21 @@
 'use strict'
+
 const React = require('react/addons')
 const TestUtils = React.addons.TestUtils
 const assert = require('chai').assert
 const ListDescription = require('../../src/components/list-description/list-description.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('ListDescriptionComponent ', function () {
   it('is an element', function () {
-    assert.ok(TestUtils.isElement(<ListDescription />))
+    assert.ok(TestUtils.isElement(<Wrapper><ListDescription /></Wrapper>))
   })
 
   it('should render an description list item with a class of component-list-description', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <ListDescription />
+      <Wrapper>
+        <ListDescription />
+      </Wrapper>
     )
 
     const renderedListDescription = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-list-description')

--- a/test/components/list-item-test.jsx
+++ b/test/components/list-item-test.jsx
@@ -1,17 +1,21 @@
 'use strict'
+
 const React = require('react/addons')
 const TestUtils = React.addons.TestUtils
 const assert = require('chai').assert
 const ListItem = require('../../src/components/list-item/list-item.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('ListItemComponent ', function () {
   it('is an element', function () {
-    assert.ok(TestUtils.isElement(<ListItem />))
+    assert.ok(TestUtils.isElement(<Wrapper><ListItem /></Wrapper>))
   })
 
   it('should render an list item with a class of component-list-item', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <ListItem />
+      <Wrapper>
+        <ListItem />
+      </Wrapper>
     )
 
     const renderedListItem = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-list-item')

--- a/test/components/list-term-test.jsx
+++ b/test/components/list-term-test.jsx
@@ -1,17 +1,21 @@
 'use strict'
+
 const React = require('react/addons')
 const TestUtils = React.addons.TestUtils
 const assert = require('chai').assert
 const ListTerm = require('../../src/components/list-term/list-term.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('ListTermComponent ', function () {
   it('is an element', function () {
-    assert.ok(TestUtils.isElement(<ListTerm />))
+    assert.ok(TestUtils.isElement(<Wrapper><ListTerm /></Wrapper>))
   })
 
   it('should render an list term with a class of component-list-term', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <ListTerm />
+      <Wrapper>
+        <ListTerm />
+      </Wrapper>
     )
 
     const renderedListTerm = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-list-term')

--- a/test/components/list-test.jsx
+++ b/test/components/list-test.jsx
@@ -3,6 +3,7 @@ const React = require('react/addons')
 const TestUtils = React.addons.TestUtils
 const assert = require('chai').assert
 const List = require('../../src/components/list/list.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('ListComponent ', function () {
   it('is an element', function () {
@@ -11,7 +12,9 @@ describe('ListComponent ', function () {
 
   it('should render an unordered list with a class of component-unordered-list', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <List type='unordered' />
+      <Wrapper>
+        <List type='unordered' />
+      </Wrapper>
     )
 
     const renderedList = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-unordered-list')
@@ -20,7 +23,9 @@ describe('ListComponent ', function () {
 
   it('should render an ordered list with a class of component-ordered-list', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <List type='ordered' />
+      <Wrapper>
+        <List type='ordered' />
+      </Wrapper>
     )
 
     const renderedList = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-ordered-list')
@@ -29,7 +34,9 @@ describe('ListComponent ', function () {
 
   it('should render an description list with a class of component-description-list', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <List type='description' />
+      <Wrapper>
+        <List type='description' />
+      </Wrapper>
     )
 
     const renderedList = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-description-list')
@@ -38,7 +45,9 @@ describe('ListComponent ', function () {
 
   it('should render an icon list with a class of component-icon-list', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <List type='icon' />
+      <Wrapper>
+        <List type='icon' />
+      </Wrapper>
     )
 
     const renderedList = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-icon-list')
@@ -47,7 +56,9 @@ describe('ListComponent ', function () {
 
   it('should render an unordered list with a class of component-unordered-list if type is undefined', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <List />
+      <Wrapper>
+        <List />
+      </Wrapper>
     )
 
     const renderedList = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-unordered-list')
@@ -56,7 +67,9 @@ describe('ListComponent ', function () {
 
   it('should render an unordered list with a class of component-unordered-list if type is unrecognised', function () {
     const ListInstance = TestUtils.renderIntoDocument(
-      <List type='gibberish' />
+      <Wrapper>
+        <List type='gibberish' />
+      </Wrapper>
     )
 
     const renderedList = TestUtils.findRenderedDOMComponentWithClass(ListInstance, 'component-unordered-list')

--- a/test/components/lozenge-test.jsx
+++ b/test/components/lozenge-test.jsx
@@ -1,27 +1,41 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const Lozenge = require('../../src/components/lozenge/lozenge.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('Lozenge', function () {
   it('is an element', function () {
-    assert.ok(TestUtils.isElement(<Lozenge />))
+    assert.ok(TestUtils.isElement(<Wrapper><Lozenge /></Wrapper>))
   })
 
   it('renders a span', function () {
-    const instance = TestUtils.renderIntoDocument(<Lozenge tip='foo'>bar</Lozenge>)
+    const instance = TestUtils.renderIntoDocument(
+      <Wrapper>
+        <Lozenge tip='foo'>bar</Lozenge>
+      </Wrapper>
+    )
     assert.ok(TestUtils.findRenderedDOMComponentWithTag(instance, 'span'))
   })
 
   it('renders the children', function () {
-    const rendered = TestUtils.renderIntoDocument(<Lozenge tip='foo'>bar</Lozenge>)
+    const rendered = TestUtils.renderIntoDocument(
+      <Wrapper>
+        <Lozenge tip='foo'>bar</Lozenge>
+      </Wrapper>
+    )
     assert.equal(TestUtils.findRenderedDOMComponentWithTag(rendered, 'span').innerHTML, 'bar')
   })
 
   describe('with tip', function () {
     beforeEach(function () {
-      this.instance = TestUtils.renderIntoDocument(<Lozenge tip='foo'>bar</Lozenge>)
+      this.instance = TestUtils.renderIntoDocument(
+        <Wrapper>
+          <Lozenge tip='foo'>bar</Lozenge>
+        </Wrapper>
+      )
     })
 
     it('sets the tip as the title', function () {
@@ -32,7 +46,11 @@ describe('Lozenge', function () {
 
   describe('without tip', function () {
     beforeEach(function () {
-      this.instance = TestUtils.renderIntoDocument(<Lozenge>bar</Lozenge>)
+      this.instance = TestUtils.renderIntoDocument(
+        <Wrapper>
+          <Lozenge>bar</Lozenge>
+        </Wrapper>
+      )
     })
 
     it('should not set a tip as the title', function () {
@@ -44,7 +62,11 @@ describe('Lozenge', function () {
   describe('with purpose attribute', function () {
     describe('primary', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge purpose='primary'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge purpose='primary'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders primary class', function () {
@@ -54,7 +76,11 @@ describe('Lozenge', function () {
 
     describe('success', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge purpose='success'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge purpose='success'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders success class', function () {
@@ -64,7 +90,11 @@ describe('Lozenge', function () {
 
     describe('info', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge purpose='info'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge purpose='info'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders info class', function () {
@@ -74,7 +104,11 @@ describe('Lozenge', function () {
 
     describe('warning', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge purpose='warning'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge purpose='warning'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders warning class', function () {
@@ -84,7 +118,11 @@ describe('Lozenge', function () {
 
     describe('danger', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge purpose='danger'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge purpose='danger'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders danger class', function () {
@@ -95,7 +133,11 @@ describe('Lozenge', function () {
   describe('with size attribute', function () {
     describe('small', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge size='small'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge size='small'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders small class', function () {
@@ -104,7 +146,11 @@ describe('Lozenge', function () {
     })
     describe('medium', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge size='medium'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge size='medium'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders medium class', function () {
@@ -113,7 +159,11 @@ describe('Lozenge', function () {
     })
     describe('large', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge size='large'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge size='large'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders large class', function () {
@@ -122,7 +172,11 @@ describe('Lozenge', function () {
     })
     describe('extra-large', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge size='extra-large'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge size='extra-large'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders extra-large class', function () {
@@ -131,7 +185,11 @@ describe('Lozenge', function () {
     })
     describe('block', function () {
       beforeEach(function () {
-        this.instance = TestUtils.renderIntoDocument(<Lozenge size='block'>foo</Lozenge>)
+        this.instance = TestUtils.renderIntoDocument(
+          <Wrapper>
+            <Lozenge size='block'>foo</Lozenge>
+          </Wrapper>
+        )
       })
 
       it('renders block class', function () {

--- a/test/components/payment-card-test.jsx
+++ b/test/components/payment-card-test.jsx
@@ -1,14 +1,18 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const PaymentCardView = require('../../src/components/payment-card/payment-card.jsx')
 const sinon = require('sinon')
+const Wrapper = require('../helpers/wrapper')
 
 describe('PaymentCardComponent', function () {
   it('should render an Amazon card', function () {
     const amazonPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='amazon' />
+      <Wrapper>
+        <PaymentCardView type='amazon' />
+      </Wrapper>
     )
 
     const renderedAmazon = TestUtils.findRenderedDOMComponentWithClass(amazonPaymentCard, 'amazon')
@@ -17,7 +21,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Amex card', function () {
     const amexPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='amex' />
+      <Wrapper>
+        <PaymentCardView type='amex' />
+      </Wrapper>
     )
 
     const renderedAmex = TestUtils.findRenderedDOMComponentWithClass(amexPaymentCard, 'amex')
@@ -26,7 +32,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Apple card', function () {
     const applePaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='apple' />
+      <Wrapper>
+        <PaymentCardView type='apple' />
+      </Wrapper>
     )
 
     const renderedApple = TestUtils.findRenderedDOMComponentWithClass(applePaymentCard, 'apple')
@@ -35,7 +43,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Cirrus card', function () {
     const cirrusPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='cirrus' />
+      <Wrapper>
+        <PaymentCardView type='cirrus' />
+      </Wrapper>
     )
 
     const renderedCirrus = TestUtils.findRenderedDOMComponentWithClass(cirrusPaymentCard, 'cirrus')
@@ -44,7 +54,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Delta card', function () {
     const deltaPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='delta' />
+      <Wrapper>
+        <PaymentCardView type='delta' />
+      </Wrapper>
     )
 
     const renderedDelta = TestUtils.findRenderedDOMComponentWithClass(deltaPaymentCard, 'delta')
@@ -53,7 +65,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Direct Debit card', function () {
     const directDebitPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='directdebit' />
+      <Wrapper>
+        <PaymentCardView type='directdebit' />
+      </Wrapper>
     )
 
     const renderedDirectDebit = TestUtils.findRenderedDOMComponentWithClass(directDebitPaymentCard, 'directdebit')
@@ -62,7 +76,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Discover card', function () {
     const discoverPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='discover' />
+      <Wrapper>
+        <PaymentCardView type='discover' />
+      </Wrapper>
     )
 
     const renderedDiscover = TestUtils.findRenderedDOMComponentWithClass(discoverPaymentCard, 'discover')
@@ -71,7 +87,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Electron card', function () {
     const electronPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='electron' />
+      <Wrapper>
+        <PaymentCardView type='electron' />
+      </Wrapper>
     )
 
     const renderedElectron = TestUtils.findRenderedDOMComponentWithClass(electronPaymentCard, 'electron')
@@ -80,7 +98,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Google card', function () {
     const googlePaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='google' />
+      <Wrapper>
+        <PaymentCardView type='google' />
+      </Wrapper>
     )
 
     const renderedGoogle = TestUtils.findRenderedDOMComponentWithClass(googlePaymentCard, 'google')
@@ -89,7 +109,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Maestro card', function () {
     const maestroPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='maestro' />
+      <Wrapper>
+        <PaymentCardView type='maestro' />
+      </Wrapper>
     )
 
     const renderedMaestro = TestUtils.findRenderedDOMComponentWithClass(maestroPaymentCard, 'maestro')
@@ -98,7 +120,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Mastercard card', function () {
     const mastercardPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='mastercard' />
+      <Wrapper>
+        <PaymentCardView type='mastercard' />
+      </Wrapper>
     )
 
     const renderedMastercard = TestUtils.findRenderedDOMComponentWithClass(mastercardPaymentCard, 'mastercard')
@@ -107,7 +131,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Paym card', function () {
     const paymPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='paym' />
+      <Wrapper>
+        <PaymentCardView type='paym' />
+      </Wrapper>
     )
 
     const renderedPaym = TestUtils.findRenderedDOMComponentWithClass(paymPaymentCard, 'paym')
@@ -116,7 +142,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Paypal card', function () {
     const paypalPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='paypal' />
+      <Wrapper>
+        <PaymentCardView type='paypal' />
+      </Wrapper>
     )
 
     const renderedPaypal = TestUtils.findRenderedDOMComponentWithClass(paypalPaymentCard, 'paypal')
@@ -125,7 +153,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Sage card', function () {
     const sagePaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='sage' />
+      <Wrapper>
+        <PaymentCardView type='sage' />
+      </Wrapper>
     )
 
     const renderedSage = TestUtils.findRenderedDOMComponentWithClass(sagePaymentCard, 'sage')
@@ -134,7 +164,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Sepa card', function () {
     const sepaPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='sepa' />
+      <Wrapper>
+        <PaymentCardView type='sepa' />
+      </Wrapper>
     )
 
     const renderedSepa = TestUtils.findRenderedDOMComponentWithClass(sepaPaymentCard, 'sepa')
@@ -143,7 +175,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Solo card', function () {
     const soloPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='solo' />
+      <Wrapper>
+        <PaymentCardView type='solo' />
+      </Wrapper>
     )
 
     const renderedSolo = TestUtils.findRenderedDOMComponentWithClass(soloPaymentCard, 'solo')
@@ -152,7 +186,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Switch card', function () {
     const switchPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='switch' />
+      <Wrapper>
+        <PaymentCardView type='switch' />
+      </Wrapper>
     )
 
     const renderedSwitch = TestUtils.findRenderedDOMComponentWithClass(switchPaymentCard, 'switch')
@@ -161,7 +197,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Ukash card', function () {
     const ukashPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='ukash' />
+      <Wrapper>
+        <PaymentCardView type='ukash' />
+      </Wrapper>
     )
 
     const renderedUkash = TestUtils.findRenderedDOMComponentWithClass(ukashPaymentCard, 'ukash')
@@ -170,7 +208,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Visa card', function () {
     const visaPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='visa' />
+      <Wrapper>
+        <PaymentCardView type='visa' />
+      </Wrapper>
     )
 
     const renderedVisa = TestUtils.findRenderedDOMComponentWithClass(visaPaymentCard, 'visa')
@@ -179,7 +219,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Visa Debit card', function () {
     const visadebitPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='visadebit' />
+      <Wrapper>
+        <PaymentCardView type='visadebit' />
+      </Wrapper>
     )
 
     const renderedVisaDebit = TestUtils.findRenderedDOMComponentWithClass(visadebitPaymentCard, 'visadebit')
@@ -188,7 +230,9 @@ describe('PaymentCardComponent', function () {
 
   it('should render an Western Union card', function () {
     const westernUnionPaymentCard = TestUtils.renderIntoDocument(
-      <PaymentCardView type='westernunion' />
+      <Wrapper>
+        <PaymentCardView type='westernunion' />
+      </Wrapper>
     )
 
     const renderedWesternUnion = TestUtils.findRenderedDOMComponentWithClass(westernUnionPaymentCard, 'westernunion')
@@ -201,7 +245,9 @@ describe('PaymentCardComponent', function () {
     beforeEach(function () {
       handler = sinon.stub()
       const card = TestUtils.renderIntoDocument(
-        <PaymentCardView onClick={handler} />
+        <Wrapper>
+          <PaymentCardView onClick={handler} />
+        </Wrapper>
       )
 
       const cardElement = TestUtils.findRenderedDOMComponentWithClass(card, 'component-payment-card')
@@ -215,7 +261,9 @@ describe('PaymentCardComponent', function () {
 
   it('should allow other attributes', function () {
     const card = TestUtils.renderIntoDocument(
-      <PaymentCardView id='foo' />
+      <Wrapper>
+        <PaymentCardView id='foo' />
+      </Wrapper>
     )
 
     const cardElement = TestUtils.findRenderedDOMComponentWithClass(card, 'component-payment-card')

--- a/test/components/quote-test.jsx
+++ b/test/components/quote-test.jsx
@@ -1,13 +1,17 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const QuoteComponent = require('../../src/components/quote/quote.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('QuoteComponent', function () {
   it('should render an Quote', function () {
     const quote = TestUtils.renderIntoDocument(
-      <QuoteComponent>I am content</QuoteComponent>
+      <Wrapper>
+        <QuoteComponent>I am content</QuoteComponent>
+      </Wrapper>
     )
 
     const renderedQuote = TestUtils.findRenderedDOMComponentWithClass(quote, 'component-quote')
@@ -16,7 +20,9 @@ describe('QuoteComponent', function () {
 
   it('should render a danger quote', function () {
     const dangerQuote = TestUtils.renderIntoDocument(
-      <QuoteComponent purpose='danger'>This is dangerous</QuoteComponent>
+      <Wrapper>
+        <QuoteComponent purpose='danger'>This is dangerous</QuoteComponent>
+      </Wrapper>
     )
 
     const renderedQuote = TestUtils.findRenderedDOMComponentWithClass(dangerQuote, 'danger')
@@ -25,7 +31,9 @@ describe('QuoteComponent', function () {
 
   it('should render a success quote', function () {
     const successQuote = TestUtils.renderIntoDocument(
-      <QuoteComponent purpose='success'>This is information</QuoteComponent>
+      <Wrapper>
+        <QuoteComponent purpose='success'>This is information</QuoteComponent>
+      </Wrapper>
     )
 
     const renderedQuote = TestUtils.findRenderedDOMComponentWithClass(successQuote, 'success')
@@ -34,7 +42,9 @@ describe('QuoteComponent', function () {
 
   it('should render a quote with a cite', function () {
     const citeQuote = TestUtils.renderIntoDocument(
-      <QuoteComponent cite='Twitter' />
+      <Wrapper>
+        <QuoteComponent cite='Twitter' />
+      </Wrapper>
     )
 
     const renderedQuote = TestUtils.findRenderedDOMComponentWithClass(citeQuote, 'component-quote')
@@ -43,7 +53,9 @@ describe('QuoteComponent', function () {
 
   it('should render a quote with an author', function () {
     const authorQuote = TestUtils.renderIntoDocument(
-      <QuoteComponent author='Timmy Test' />
+      <Wrapper>
+        <QuoteComponent author='Timmy Test' />
+      </Wrapper>
     )
 
     const renderedQuote = TestUtils.findRenderedDOMComponentWithClass(authorQuote, 'component-quote')
@@ -52,7 +64,9 @@ describe('QuoteComponent', function () {
 
   it('should render a quote with a role', function () {
     const roleQuote = TestUtils.renderIntoDocument(
-      <QuoteComponent role='Developer' />
+      <Wrapper>
+        <QuoteComponent role='Developer' />
+      </Wrapper>
     )
 
     const renderedQuote = TestUtils.findRenderedDOMComponentWithClass(roleQuote, 'component-quote')
@@ -61,7 +75,9 @@ describe('QuoteComponent', function () {
 
   it('should render a quote with a role', function () {
     const inlineQuote = TestUtils.renderIntoDocument(
-      <QuoteComponent type='inline'>Inline Quote</QuoteComponent>
+      <Wrapper>
+        <QuoteComponent type='inline'>Inline Quote</QuoteComponent>
+      </Wrapper>
     )
 
     const renderedQuote = TestUtils.findRenderedDOMComponentWithClass(inlineQuote, 'inline')

--- a/test/components/rating-test.jsx
+++ b/test/components/rating-test.jsx
@@ -1,4 +1,5 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert

--- a/test/components/reviews-test.jsx
+++ b/test/components/reviews-test.jsx
@@ -1,13 +1,17 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const ReviewsComponent = require('../../src/components/reviews/reviews.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 describe('ReviewsComponent', function () {
   it('should render review percentage and review count', function () {
     const reviewView = TestUtils.renderIntoDocument(
-      <ReviewsComponent reviewPercentage={98} reviewCount={123} />
+      <Wrapper>
+        <ReviewsComponent reviewPercentage={98} reviewCount={123} />
+      </Wrapper>
     )
 
     const reviewText = TestUtils.findRenderedDOMComponentWithClass(reviewView, 'ui-component-reviews')

--- a/test/components/select-test.jsx
+++ b/test/components/select-test.jsx
@@ -1,4 +1,5 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert

--- a/test/components/tile-test.jsx
+++ b/test/components/tile-test.jsx
@@ -1,9 +1,11 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const TileComponent = require('../../src/components/tile/tile.jsx')
 const sinon = require('sinon')
+const Wrapper = require('../helpers/wrapper')
 
 describe('TileComponent', function () {
   let img
@@ -17,7 +19,9 @@ describe('TileComponent', function () {
 
   it('is an element', function () {
     const component = TestUtils.renderIntoDocument(
-      <TileComponent image={img} />
+      <Wrapper>
+        <TileComponent image={img} />
+      </Wrapper>
     )
 
     assert.isDefined(component)
@@ -25,7 +29,9 @@ describe('TileComponent', function () {
 
   it('should render an img', function () {
     const tile = TestUtils.renderIntoDocument(
-      <TileComponent image={img}>bar</TileComponent>
+      <Wrapper>
+        <TileComponent image={img}>bar</TileComponent>
+      </Wrapper>
     )
     const renderedImg = TestUtils.scryRenderedDOMComponentsWithTag(tile, 'img')
     assert.equal(renderedImg.length, 1)
@@ -33,7 +39,9 @@ describe('TileComponent', function () {
 
   it('should render a tile-block', function () {
     const tile = TestUtils.renderIntoDocument(
-      <TileComponent image={img}>bar</TileComponent>
+      <Wrapper>
+        <TileComponent image={img}>bar</TileComponent>
+      </Wrapper>
     )
     const renderedTile = TestUtils.findRenderedDOMComponentWithClass(tile, 'component-tile-block')
     assert.isDefined(renderedTile)
@@ -42,7 +50,9 @@ describe('TileComponent', function () {
   it('should render any extra props passed to it on the containing div', function () {
     const onClickHandler = sinon.stub()
     const tile = TestUtils.renderIntoDocument(
-      <TileComponent image={img} title='foo' onClick={onClickHandler} />
+      <Wrapper>
+        <TileComponent image={img} title='foo' onClick={onClickHandler} />
+      </Wrapper>
     )
     const renderedTile = TestUtils.findRenderedDOMComponentWithClass(tile, 'component-tile')
     TestUtils.Simulate.click(renderedTile)

--- a/test/components/weather-test.jsx
+++ b/test/components/weather-test.jsx
@@ -1,9 +1,10 @@
 'use strict'
+
 const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
-
 const WeatherComponent = require('../../src/components/weather/weather.jsx')
+const Wrapper = require('../helpers/wrapper')
 
 let type = null
 let temperature = null
@@ -13,7 +14,7 @@ describe('WeatherComponent', function () {
   temperature = 20
 
   it('is an element', function () {
-    assert.ok(TestUtils.isElement(<WeatherComponent type={type} temperature={temperature} />))
+    assert.ok(TestUtils.isElement(<Wrapper><WeatherComponent type={type} temperature={temperature} /></Wrapper>))
   })
 
   describe('Can accept all types of weather', function () {
@@ -25,7 +26,9 @@ describe('WeatherComponent', function () {
       type = 'cloudy'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -36,7 +39,9 @@ describe('WeatherComponent', function () {
       type = 'fog'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -47,7 +52,9 @@ describe('WeatherComponent', function () {
       type = 'hail'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -58,7 +65,9 @@ describe('WeatherComponent', function () {
       type = 'heavy-rain'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -69,7 +78,9 @@ describe('WeatherComponent', function () {
       type = 'heavy-snow'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -80,7 +91,9 @@ describe('WeatherComponent', function () {
       type = 'light-rain'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -91,7 +104,9 @@ describe('WeatherComponent', function () {
       type = 'light-snow'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -102,7 +117,9 @@ describe('WeatherComponent', function () {
       type = 'night-clear'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -113,7 +130,9 @@ describe('WeatherComponent', function () {
       type = 'night-partly-cloudy'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -124,7 +143,9 @@ describe('WeatherComponent', function () {
       type = 'partly-cloudy'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -135,7 +156,9 @@ describe('WeatherComponent', function () {
       type = 'storm'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -146,7 +169,9 @@ describe('WeatherComponent', function () {
       type = 'sunny'
 
       const weatherType = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherType, 'div')[1]
@@ -161,7 +186,9 @@ describe('WeatherComponent', function () {
     describe('is a perfectly valid date', function () {
       it('displays date in full day of week format', function () {
         const weatherDate = TestUtils.renderIntoDocument(
-          <WeatherComponent type={type} date='2017-07-27' format='dddd' />
+          <Wrapper>
+            <WeatherComponent type={type} date='2017-07-27' format='dddd' />
+          </Wrapper>
         )
 
         const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherDate, 'div')[2]
@@ -172,7 +199,9 @@ describe('WeatherComponent', function () {
     describe('is an invalid date', function () {
       it('fails to display date instead throws invalid date error', function () {
         const weatherDate = TestUtils.renderIntoDocument(
-          <WeatherComponent type={type} date='20027-07-2017' format='dddd' />
+          <Wrapper>
+            <WeatherComponent type={type} date='20027-07-2017' format='dddd' />
+          </Wrapper>
         )
 
         const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherDate, 'div')[2]
@@ -188,7 +217,9 @@ describe('WeatherComponent', function () {
 
     it('displays temperature in Celsius', function () {
       const weatherTemp = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} unit='C' />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} unit='C' />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherTemp, 'div')[2]
@@ -197,7 +228,9 @@ describe('WeatherComponent', function () {
 
     it('displays temperature in Fahrenheit', function () {
       const weatherTemp = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} unit='F' />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} unit='F' />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherTemp, 'div')[2]
@@ -206,7 +239,9 @@ describe('WeatherComponent', function () {
 
     it('displays temperature in Rankine', function () {
       const weatherTemp = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} unit='R' />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} unit='R' />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherTemp, 'div')[2]
@@ -215,7 +250,9 @@ describe('WeatherComponent', function () {
 
     it('displays temperature in Kelvin', function () {
       const weatherTemp = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={temperature} unit='K' />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={temperature} unit='K' />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherTemp, 'div')[2]
@@ -224,7 +261,9 @@ describe('WeatherComponent', function () {
 
     it('displays a temperature at 0', function () {
       const weatherTemp = TestUtils.renderIntoDocument(
-        <WeatherComponent type={type} temperature={0} unit='C' />
+        <Wrapper>
+          <WeatherComponent type={type} temperature={0} unit='C' />
+        </Wrapper>
       )
 
       const renderedWeather = TestUtils.scryRenderedDOMComponentsWithTag(weatherTemp, 'div')[2]

--- a/test/helpers/wrapper.jsx
+++ b/test/helpers/wrapper.jsx
@@ -1,0 +1,22 @@
+'use strict'
+
+const React = require('react')
+
+/**
+ * TestUtils.renderIntoDocument() doesn't support rendering
+ * functional components, so to test rendering them we have to wrap
+ * them in an ES2015 class based component.
+ *
+ * This will be made redundant by enzyme unit tests.
+ */
+class Wrapper extends React.Component {
+  render () {
+    /**
+     * wrap the real component in a <section> tag
+     * as it's unlikely a test will be looking for that.
+     */
+    return <section>{this.props.children}</section>
+  }
+}
+
+module.exports = Wrapper


### PR DESCRIPTION
## Purpose
This PR is preparation for React 16, which doesn't support `React.createClass()` and so all components have to be made either functional or use ES2015 classes. In this PR I've changed all the components which don't rely on mixins or local state to be functional components, which only leaves ~4 components to convert in a future PR.

## Tech debt
The test rendering library we're using from React 14 doesn't support rendering functional components, so I've had to create a `Wrapper` class for them to render in tests. This can be removed when we move to a more up-to-date testing library like enzyme or jest.

## Testing
* Does the build pass?
* Can you run `npm docs` and check all the components still work?