### PR TITLE
Fix transpilation of countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 3.1.1 - 2017-11-08
+- Fix build error where countdown component libs weren't transpiled
+
 ### 3.1.0 - 2017-11-07
 - Use standard for linting
 - Use const & let

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/ui-toolkit",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "UI Toolkit",
   "license": "MIT",
   "main": "index.js",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,3 +5,8 @@ for tool in $( ls -1 $SRCFOLDER ); do
   mkdir -p $DISTFOLDER/$tool
   babel $SRCFOLDER/$tool/$tool.jsx -o $DISTFOLDER/$tool/index.js
 done
+
+# the countdown component has a slightly different structure
+mkdir -p $DISTFOLDER/countdown/lib
+babel $SRCFOLDER/countdown/lib/countdown.js -o $DISTFOLDER/countdown/lib/countdown.js
+babel $SRCFOLDER/countdown/lib/countdownManager.js -o $DISTFOLDER/countdown/lib/countdownManager.js

--- a/src/components/countdown/countdown.jsx
+++ b/src/components/countdown/countdown.jsx
@@ -1,7 +1,7 @@
 'use strict'
 
 const React = require('react')
-const CountdownManager = require('../../../src/components/countdown/lib/countdownManager')
+const CountdownManager = require('./lib/countdownManager')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
 


### PR DESCRIPTION
In v3.1.0 I linted the code base with standardjs and also changed var to const, expecting it to be transpiled back in the dist build anyway. As it happens that happens for all but two files 🙄 

The files in `src/components/countdown/lib` weren't transpiled and had a weird require path to them so that components in dist could refer to them back in the src folder. This beartrap continued to work, but the const declarations in that file weren't transpiled, breaking the tripapp uglify step.

This PR makes sure all the src files are transpiled by adding some special case logic to the build script.