### PR TITLE
Convert React.createClass to es2015 classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.3.0 - 2017-11-10
+- Remove all use of mixins
+- Convert more components to es2015 classes or functional components
+
 ### 3.2.0 - 2017-11-09
 - Make components not using mixins or state functional
 

--- a/docs/src/Components.jsx
+++ b/docs/src/Components.jsx
@@ -17,7 +17,7 @@ var Components = React.createClass({
             <CustomComponent codeText={fs.readFileSync(__dirname + '/../examples/Anchor.jsx', 'utf8')} />
             <h4>Attributes</h4>
             <ul>
-              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values (uses <a href="https://github.com/holidayextras/react-data-attributes-mixin" alt="React Data Attributes Mixin">React Data Attributes Mixin</a>)</li>
+              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values</li>
               <li><code>handleClick</code> Function - handle click events on the anchor</li>
               <li><code>href</code> String - The location you want to anchor to</li>
               <li><code>target</code> String - This attribute specifies where to display the linked resource. Can be <code>_self</code>, <code>_blank</code>, <code>_parent</code> or <code>_top</code></li>
@@ -38,7 +38,7 @@ var Components = React.createClass({
             <CustomComponent codeText={fs.readFileSync(__dirname + '/../examples/ButtonBlock.jsx', 'utf8')} />
             <h4>Attributes</h4>
             <ul>
-              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values (uses <a href="https://github.com/holidayextras/react-data-attributes-mixin" alt="React Data Attributes Mixin">React Data Attributes Mixin</a>)</li>
+              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values</li>
               <li><code>disabled</code> Boolean - Determines the state of the button</li>
               <li><code>href</code> String - If an href is passed to a button, it changes to an anchor with button styling</li>
               <li><code>purpose</code> String - default, primary, secondary, success, info, warning, danger</li>
@@ -95,7 +95,7 @@ var Components = React.createClass({
               <li><code>src</code> String - Image src attribute</li>
               <li><code>href</code> String - an href that wraps the image in an anchor</li>
               <li><code>target</code> String (optional) - passed through to a wrapping anchor if href is provided. See the <a href="#anchor">Anchor</a> component for the set of valid values.</li>
-              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values (uses <a href="https://github.com/holidayextras/react-data-attributes-mixin" alt="React Data Attributes Mixin">React Data Attributes Mixin</a>)</li>
+              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values</li>
               <li><code>srcset</code> String - a comma separated list of images and their file size, perfect for responsive images</li>
               <li><code>sizes</code> String (optional) - A rough start size for your image. To be used in conjunction with srcset when implementing responsive images. Please note that this is an optimisation only and its default is set to <code>100vw</code></li>
             </ul>
@@ -107,7 +107,7 @@ var Components = React.createClass({
             <CustomComponent codeText={fs.readFileSync(__dirname + '/../examples/Input.jsx', 'utf8')} />
             <h4>Attributes</h4>
             <ul>
-              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values (uses <a href="https://github.com/holidayextras/react-data-attributes-mixin" alt="React Data Attributes Mixin">React Data Attributes Mixin</a>)</li>
+              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values</li>
               <li><code>type</code> String - Type of Input Field can be <code>text</code>, <code>email</code>, <code>tel</code> or <code>number</code></li>
               <li><code>name</code> String - Optional Name for Input Field</li>
               <li><code>id</code> String - Optional ID for Input Field</li>
@@ -132,7 +132,7 @@ var Components = React.createClass({
               <li><code>id</code> String - Optional ID for Input Field</li>
               <li><code>label</code> String - Optional Label in front of Input Field</li>
               <li><code>handleChange</code> Function - Optional Function which is called onChange</li>
-              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values (uses <a href="https://github.com/holidayextras/react-data-attributes-mixin" alt="React Data Attributes Mixin">React Data Attributes Mixin</a>)</li>
+              <li><code>data</code> Object - Where <code>keys</code> will be data attributes and <code>values</code> will be their values</li>
               <li><code>name</code> String - Optional Boolean for multiple select</li>
             </ul>
           </article>

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "moment": "^2.14.1",
     "prop-types": "^15.6.0",
     "react": "^0.14.8",
-    "react-data-attributes-mixin": "git://github.com/holidayextras/react-data-attributes-mixin",
     "react-dom": "^0.14.8",
     "reactify": "^1.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holidayextras/ui-toolkit",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "UI Toolkit",
   "license": "MIT",
   "main": "index.js",

--- a/src/components/anchor/anchor.jsx
+++ b/src/components/anchor/anchor.jsx
@@ -1,39 +1,53 @@
 'use strict'
 
 const React = require('react')
-const DataAttributesMixin = require('react-data-attributes-mixin')
 const PropTypes = require('prop-types')
+const { flatten } = require('../helpers')
 
-module.exports = React.createClass({
-
-  mixins: [DataAttributesMixin],
-
-  getDefaultProps: function () {
-    return {
-      href: '#',
-      role: 'link'
-    }
-  },
-
-  propTypes: {
-    handleClick: PropTypes.func,
-    children: PropTypes.node,
-    data: PropTypes.object,
-    href: PropTypes.string,
-    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
-    title: PropTypes.string,
-    role: PropTypes.string
-  },
-
-  render: function () {
-    if (!this.props.children) {
-      return null
-    }
-    const dataAttributes = this.getDataAttributesFromProps()
-    return (
-      <a className='component-anchor' {...dataAttributes} title={this.props.title} role={this.props.role} href={this.props.href} onClick={this.props.handleClick} target={this.props.target}>
-        {this.props.children}
-      </a>
-    )
+const Anchor = ({
+  children,
+  data,
+  title,
+  role,
+  href,
+  handleClick,
+  target
+}) => {
+  if (!children) {
+    // TODO - return null
+    // React < 15 doesn't allow returning null from functional components.
+    // See: https://github.com/facebook/react/issues/5355
+    return <noscript />
   }
-})
+  const dataAttributes = flatten(data)
+  return (
+    <a
+      className='component-anchor'
+      {...dataAttributes}
+      title={title}
+      role={role}
+      href={href}
+      onClick={handleClick}
+      target={target}
+    >
+      {children}
+    </a>
+  )
+}
+
+Anchor.propTypes = {
+  handleClick: PropTypes.func,
+  children: PropTypes.node,
+  data: PropTypes.object,
+  href: PropTypes.string,
+  target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
+  title: PropTypes.string,
+  role: PropTypes.string
+}
+
+Anchor.defaultProps = {
+  href: '#',
+  role: 'link'
+}
+
+module.exports = Anchor

--- a/src/components/basket-item/basket-item.jsx
+++ b/src/components/basket-item/basket-item.jsx
@@ -4,62 +4,81 @@ const React = require('react')
 const Anchor = require('../anchor')
 const PropTypes = require('prop-types')
 
-module.exports = React.createClass({
-  propTypes: {
-    price: PropTypes.node,
-    title: PropTypes.node,
-    toggleDescription: PropTypes.bool,
-    handleRemove: PropTypes.func,
-    children: PropTypes.node
-  },
-  getInitialState: function () {
-    return {
-      descriptionVisibility: !this.props.toggleDescription
+class BasketItem extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      descriptionVisibility: !props.toggleDescription
     }
-  },
-  getDefaultProps: function () {
-    return {
-      title: null,
-      price: null,
-      handleRemove: null,
-      toggleDescription: false
-    }
-  },
-  toggleDescriptionVisibility: function (e) {
+
+    this.toggleDescriptionVisibility = this.toggleDescriptionVisibility.bind(this)
+  }
+
+  toggleDescriptionVisibility (e) {
     e.preventDefault()
     e.stopPropagation()
     this.setState({ descriptionVisibility: !this.state.descriptionVisibility })
-  },
-  titleNode: function () {
-    if (this.props.title === null) return null
+  }
+
+  titleNode () {
+    const { title, toggleDescription } = this.props
+    if (title === null) return null
     // Only wrap the title if it's not an element already.
-    if (this.props.toggleDescription && !React.isValidElement(this.props.title)) return (<Anchor handleClick={this.toggleDescriptionVisibility}>{this.props.title}</Anchor>)
-    return this.props.title
-  },
-  removeNode: function () {
-    if (this.props.handleRemove === null) return null
+    if (toggleDescription && !React.isValidElement(title)) {
+      return (
+        <Anchor handleClick={this.toggleDescriptionVisibility}>
+          {title}
+        </Anchor>
+      )
+    }
+    return title
+  }
+
+  removeNode () {
+    const { handleRemove } = this.props
+    if (handleRemove === null) return null
     return (
-      <Anchor handleClick={this.props.handleRemove} role='button'>remove</Anchor>
+      <Anchor handleClick={handleRemove} role='button'>remove</Anchor>
     )
-  },
-  render: function () {
+  }
+
+  render () {
     const titleNode = this.titleNode()
     const descriptionStyle = {
       'display': (this.state.descriptionVisibility || titleNode === null) ? 'block' : 'none'
     }
+    const { children, title, price } = this.props
     return (
-      <div className='component-basket-item'>
-        {(this.props.title)
-        ? <div className='component-basket-row'>
-          <div className='component-basket-item-title'>{titleNode}</div>
-          <div className='component-basket-item-total'>{this.props.price}</div>
-        </div>
-       : null}
+      <div className='component-basket-item' >
+        {(title)
+          ? <div className='component-basket-row'>
+            <div className='component-basket-item-title'>{titleNode}</div>
+            <div className='component-basket-item-total'>{price}</div>
+          </div>
+          : null}
         <div className='component-basket-row'>
-          <div className='component-basket-item-description' style={descriptionStyle}>{this.props.children}</div>
+          <div className='component-basket-item-description' style={descriptionStyle}>{children}</div>
           <div className='component-basket-item-remove'>{this.removeNode()}</div>
         </div>
       </div>
     )
   }
-})
+}
+
+BasketItem.propTypes = {
+  price: PropTypes.node,
+  title: PropTypes.node,
+  toggleDescription: PropTypes.bool,
+  handleRemove: PropTypes.func,
+  children: PropTypes.node
+}
+
+BasketItem.defaultProps = {
+  title: null,
+  price: null,
+  handleRemove: null,
+  toggleDescription: false
+}
+
+module.exports = BasketItem

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -1,9 +1,9 @@
 'use strict'
 
 const React = require('react')
-const DataAttributesMixin = require('react-data-attributes-mixin')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
+const { flatten } = require('../helpers')
 
 const _ = {
   extend: require('lodash/extend'),
@@ -11,9 +11,6 @@ const _ = {
 }
 
 module.exports = React.createClass({
-
-  mixins: [DataAttributesMixin],
-
   propTypes: {
     children: PropTypes.any,
     purpose: PropTypes.oneOf(['default', 'primary', 'secondary', 'success', 'warning', 'danger', 'info']),
@@ -47,7 +44,7 @@ module.exports = React.createClass({
       props.onClick = props.handleClick
     }
 
-    return _.extend({}, props, this.getDataAttributesFromProps())
+    return _.extend({}, props, flatten(this.props.data))
   },
 
   render () {

--- a/src/components/helpers/helpers.jsx
+++ b/src/components/helpers/helpers.jsx
@@ -1,0 +1,12 @@
+const _ = {
+  mapKeys: require('lodash/mapKeys'),
+  kebabCase: require('lodash/kebabCase')
+}
+
+const flatten = (data) => {
+  return _.mapKeys(data, (value, key) => 'data-' + _.kebabCase(key))
+}
+
+module.exports = {
+  flatten
+}

--- a/src/components/helpers/index.js
+++ b/src/components/helpers/index.js
@@ -1,0 +1,12 @@
+const _ = {
+  mapKeys: require('lodash/mapKeys'),
+  kebabCase: require('lodash/kebabCase')
+}
+
+const flatten = (data) => {
+  return _.mapKeys(data, (value, key) => 'data-' + _.kebabCase(key))
+}
+
+module.exports = {
+  flatten
+}

--- a/src/components/helpers/index.js
+++ b/src/components/helpers/index.js
@@ -1,12 +1,3 @@
-const _ = {
-  mapKeys: require('lodash/mapKeys'),
-  kebabCase: require('lodash/kebabCase')
-}
+'use strict'
 
-const flatten = (data) => {
-  return _.mapKeys(data, (value, key) => 'data-' + _.kebabCase(key))
-}
-
-module.exports = {
-  flatten
-}
+module.exports = require('./helpers.jsx')

--- a/src/components/image/image.jsx
+++ b/src/components/image/image.jsx
@@ -1,36 +1,65 @@
 'use strict'
 
 const React = require('react')
-const DataAttributesMixin = require('react-data-attributes-mixin')
 const PropTypes = require('prop-types')
+const { flatten } = require('../helpers')
 
-module.exports = React.createClass({
-
-  mixins: [DataAttributesMixin],
-
-  propTypes: {
-    src: PropTypes.string.isRequired,
-    alt: PropTypes.string.isRequired,
-    handleClick: PropTypes.func,
-    handleLoad: PropTypes.func,
-    href: PropTypes.string,
-    target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
-    srcSet: PropTypes.string,
-    sizes: PropTypes.string
-  },
-
-  render: function () {
-    const dataAttributes = this.getDataAttributesFromProps()
-    const sizes = this.props.sizes || '100vw'
-    if (this.props.href) {
-      return (
-        <a className='component-image' href={this.props.href} target={this.props.target} onClick={this.props.handleClick} {...dataAttributes} >
-          <img src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} sizes={sizes} onLoad={this.props.handleLoad} />
-        </a>
-      )
-    }
+const Image = ({
+  src,
+  alt,
+  handleClick,
+  handleLoad,
+  href,
+  target,
+  srcSet,
+  sizes,
+  data
+}) => {
+  const dataAttributes = flatten(data)
+  const imageSizes = sizes || '100vw'
+  if (href) {
     return (
-      <img className='component-image' src={this.props.src} srcSet={this.props.srcSet} alt={this.props.alt} sizes={sizes} onClick={this.props.handleClick} onLoad={this.props.handleLoad} {...dataAttributes} />
+      <a
+        className='component-image'
+        href={href}
+        target={target}
+        onClick={handleClick}
+        {...dataAttributes}
+      >
+        <img
+          src={src}
+          srcSet={srcSet}
+          alt={alt}
+          sizes={imageSizes}
+          onLoad={handleLoad}
+        />
+      </a>
     )
   }
-})
+  return (
+    <img
+      className='component-image'
+      src={src}
+      srcSet={srcSet}
+      alt={alt}
+      sizes={imageSizes}
+      onClick={handleClick}
+      onLoad={handleLoad}
+      {...dataAttributes}
+    />
+  )
+}
+
+Image.propTypes = {
+  src: PropTypes.string.isRequired,
+  alt: PropTypes.string.isRequired,
+  handleClick: PropTypes.func,
+  handleLoad: PropTypes.func,
+  href: PropTypes.string,
+  target: PropTypes.oneOf(['_self', '_blank', '_parent', '_top']),
+  srcSet: PropTypes.string,
+  sizes: PropTypes.string,
+  data: PropTypes.object
+}
+
+module.exports = Image

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -1,14 +1,11 @@
 'use strict'
 
 const React = require('react')
-const DataAttributesMixin = require('react-data-attributes-mixin')
 const classNames = require('classnames')
 const PropTypes = require('prop-types')
+const { flatten } = require('../helpers')
 
 module.exports = React.createClass({
-
-  mixins: [DataAttributesMixin],
-
   intent: null,
 
   propTypes: {
@@ -94,7 +91,7 @@ module.exports = React.createClass({
       'error': this.state.error || false,
       'disabled': this.props.disabled || false
     })
-    const dataAttributes = this.getDataAttributesFromProps()
+    const dataAttributes = flatten(this.props.data)
 
     // the form label
     let label

--- a/src/components/select/select.jsx
+++ b/src/components/select/select.jsx
@@ -1,13 +1,10 @@
 'use strict'
 
 const React = require('react')
-const DataAttributesMixin = require('react-data-attributes-mixin')
 const PropTypes = require('prop-types')
+const { flatten } = require('../helpers')
 
 module.exports = React.createClass({
-
-  mixins: [DataAttributesMixin],
-
   propTypes: {
     label: PropTypes.string,
     name: PropTypes.string,
@@ -34,7 +31,7 @@ module.exports = React.createClass({
 
   render: function () {
     let classes = 'component-select'
-    const dataAttributes = this.getDataAttributesFromProps()
+    const dataAttributes = flatten(this.props.data)
 
     let label
     if (this.props.label) {

--- a/src/components/stepper/stepper.jsx
+++ b/src/components/stepper/stepper.jsx
@@ -5,68 +5,90 @@ const PropTypes = require('prop-types')
 const Button = require('../button')
 const Input = require('../input')
 
-module.exports = React.createClass({
+class Stepper extends React.Component {
+  constructor (props) {
+    super(props)
+    this.decrement = this.decrement.bind(this)
+    this.increment = this.increment.bind(this)
+  }
 
-  propTypes: {
-    value: PropTypes.number,
-    valueText: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-    minValue: PropTypes.number,
-    maxValue: PropTypes.number,
-    stepValue: PropTypes.number,
-    incrementDisplayString: PropTypes.string,
-    decrementDisplayString: PropTypes.string,
-    id: PropTypes.string,
-    label: PropTypes.string,
-    readOnly: PropTypes.bool
-  },
-
-  getDefaultProps: function () {
-    return {
-      value: 0,
-      stepValue: 1,
-      incrementDisplayString: '+',
-      decrementDisplayString: '-'
-    }
-  },
-
-  decrement: function () {
+  decrement () {
+    const { value, stepValue, onChange } = this.props
     if (!this.canDecrement()) return
-    this.props.onChange(this.props.value - this.props.stepValue)
-  },
+    onChange(value - stepValue)
+  }
 
-  increment: function () {
+  increment () {
+    const { value, stepValue, onChange } = this.props
     if (!this.canIncrement()) return
-    this.props.onChange(this.props.value + this.props.stepValue)
-  },
+    onChange(value + stepValue)
+  }
 
-  canIncrement: function () {
-    if (this.props.maxValue === undefined) return true
-    return this.props.value < this.props.maxValue
-  },
+  canIncrement () {
+    const { maxValue, value } = this.props
+    if (maxValue === undefined) return true
+    return value < maxValue
+  }
 
-  canDecrement: function () {
-    if (this.props.minValue === undefined) return true
-    return this.props.value > this.props.minValue
-  },
+  canDecrement () {
+    const { minValue, value } = this.props
+    if (minValue === undefined) return true
+    return value > minValue
+  }
 
-  render: function () {
-    const valueText = this.props.valueText || this.props.value
+  render () {
+    const {
+      id,
+      label,
+      value,
+      readOnly,
+      decrementDisplayString,
+      incrementDisplayString
+    } = this.props
+    const valueText = this.props.valueText || value
+
     return (
       <div className='component-stepper'>
-        <label className='component-stepper-label' htmlFor={this.props.id}>{this.props.label}</label>
+        <label className='component-stepper-label' htmlFor={id}>{label}</label>
         <div>
           <span className='button-container'>
-            <Button handleClick={this.decrement} type='button' disabled={!this.canDecrement()}>{this.props.decrementDisplayString}</Button>
+            <Button handleClick={this.decrement} type='button' disabled={!this.canDecrement()}>
+              {decrementDisplayString}
+            </Button>
           </span>
 
-          <Input type='text' id={this.props.id} key={this.props.value} readOnly={this.props.readOnly}>{valueText.toString()}</Input>
+          <Input type='text' id={id} key={value} readOnly={readOnly}>{valueText.toString()}</Input>
 
           <span className='button-container'>
-            <Button handleClick={this.increment} type='button' disabled={!this.canIncrement()}>{this.props.incrementDisplayString}</Button>
+            <Button handleClick={this.increment} type='button' disabled={!this.canIncrement()}>
+              {incrementDisplayString}
+            </Button>
           </span>
         </div>
       </div>
     )
   }
-})
+}
+
+Stepper.propTypes = {
+  value: PropTypes.number,
+  valueText: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  minValue: PropTypes.number,
+  maxValue: PropTypes.number,
+  stepValue: PropTypes.number,
+  incrementDisplayString: PropTypes.string,
+  decrementDisplayString: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
+  readOnly: PropTypes.bool
+}
+
+Stepper.defaultProps = {
+  value: 0,
+  stepValue: 1,
+  incrementDisplayString: '+',
+  decrementDisplayString: '-'
+}
+
+module.exports = Stepper

--- a/test/components/anchor-test.jsx
+++ b/test/components/anchor-test.jsx
@@ -4,6 +4,7 @@ const React = require('react')
 const TestUtils = require('react-addons-test-utils')
 const sinon = require('sinon')
 const assert = require('chai').assert
+const Wrapper = require('../helpers/wrapper')
 
 const Anchor = require('../../src/components/anchor/anchor.jsx')
 
@@ -19,7 +20,8 @@ describe('Anchor', function () {
   beforeEach(function () {
     data = {
       'foo': 'bar',
-      'x-y-z': 'zyx'
+      'x-y-z': 'zyx',
+      'mooCow': 'baa'
     }
     title = 'test'
     href = 'google.com'
@@ -27,7 +29,9 @@ describe('Anchor', function () {
     target = '_blank'
 
     instance = TestUtils.renderIntoDocument(
-      <Anchor data={data} title={title} href={href} handleClick={clickHandler} target={target} foo='bar'>test anchor</Anchor>
+      <Wrapper>
+        <Anchor data={data} title={title} href={href} handleClick={clickHandler} target={target} foo='bar'>test anchor</Anchor>
+      </Wrapper>
     )
 
     const renderedAnchor = TestUtils.findRenderedDOMComponentWithTag(instance, 'a')
@@ -47,6 +51,7 @@ describe('Anchor', function () {
       it('spreads them and prefixes with \'data\'', function () {
         assert.equal(anchorDomNode.getAttribute('data-foo'), 'bar')
         assert.equal(anchorDomNode.getAttribute('data-x-y-z'), 'zyx')
+        assert.equal(anchorDomNode.getAttribute('data-moo-cow'), 'baa')
       })
     })
 
@@ -74,7 +79,9 @@ describe('Anchor', function () {
   describe('without content', function () {
     beforeEach(function () {
       instance = TestUtils.renderIntoDocument(
-        <Anchor data={data} title={title} href={href} handleClick={clickHandler} />
+        <Wrapper>
+          <Anchor data={data} title={title} href={href} handleClick={clickHandler} />
+        </Wrapper>
       )
     })
     it('does not render', function () {
@@ -85,7 +92,9 @@ describe('Anchor', function () {
   describe('without a href', function () {
     beforeEach(function () {
       instance = TestUtils.renderIntoDocument(
-        <Anchor data={data} title={title} handleClick={clickHandler} >Content</Anchor>
+        <Wrapper>
+          <Anchor data={data} title={title} handleClick={clickHandler} >Content</Anchor>
+        </Wrapper>
       )
       const renderedAnchor = TestUtils.findRenderedDOMComponentWithTag(instance, 'a')
       anchorDomNode = renderedAnchor

--- a/test/components/image-test.jsx
+++ b/test/components/image-test.jsx
@@ -5,6 +5,7 @@ const TestUtils = require('react-addons-test-utils')
 const assert = require('chai').assert
 const ImageComponent = require('../../src/components/image/image.jsx')
 const sinon = require('sinon')
+const Wrapper = require('../helpers/wrapper')
 
 describe('ImageComponent', function () {
   let src = null
@@ -28,7 +29,7 @@ describe('ImageComponent', function () {
   })
 
   it('is an element', function () {
-    assert.ok(TestUtils.isElement(<ImageComponent src={src} alt={alt} />))
+    assert.ok(TestUtils.isElement(<Wrapper><ImageComponent src={src} alt={alt} /></Wrapper>))
   })
 
   describe('when an href is passed in', function () {
@@ -37,7 +38,9 @@ describe('ImageComponent', function () {
     beforeEach(function () {
       href = 'http://this.isa.link'
       imageInstance = TestUtils.renderIntoDocument(
-        <ImageComponent src={src} alt={alt} handleClick={handleClick} handleLoad={handleLoad} href={href} />
+        <Wrapper>
+          <ImageComponent src={src} alt={alt} handleClick={handleClick} handleLoad={handleLoad} href={href} />
+        </Wrapper>
       )
       renderedImage = TestUtils.findRenderedDOMComponentWithClass(imageInstance, 'component-image')
       anchorDOMNode = renderedImage
@@ -82,7 +85,9 @@ describe('ImageComponent', function () {
       const href = 'http://this.isa.link'
       const target = '_blank'
       imageInstance = TestUtils.renderIntoDocument(
-        <ImageComponent src={src} alt={alt} handleClick={handleClick} href={href} target={target} />
+        <Wrapper>
+          <ImageComponent src={src} alt={alt} handleClick={handleClick} href={href} target={target} />
+        </Wrapper>
       )
       renderedImage = TestUtils.findRenderedDOMComponentWithClass(imageInstance, 'component-image')
       imageDOMNode = renderedImage
@@ -96,7 +101,9 @@ describe('ImageComponent', function () {
   describe('when an href is not passed in', function () {
     beforeEach(function () {
       imageInstance = TestUtils.renderIntoDocument(
-        <ImageComponent src={src} alt={alt} handleClick={handleClick} handleLoad={handleLoad} sizes={sizes} srcSet={srcSet} />
+        <Wrapper>
+          <ImageComponent src={src} alt={alt} handleClick={handleClick} handleLoad={handleLoad} sizes={sizes} srcSet={srcSet} />
+        </Wrapper>
       )
       renderedImage = TestUtils.findRenderedDOMComponentWithClass(imageInstance, 'component-image')
       imageDOMNode = renderedImage


### PR DESCRIPTION
This PR removes a mixin to flatten data attributes as mixins aren't supported in React es2015 classes. A couple of components have also been converted to functional components. There's now just ~4 components plus some documentation to make compatibile with React 16.

To test:
* Check the test suite passes
* Run the docs site with `npm run docs`
* Check that the helper function will be transpiled by the `npm run build` script